### PR TITLE
Remove twin build for PDFs

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -287,7 +287,6 @@ latex_elements = {
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
     ('formal', 'formal.tex', u'CellML Specification', u'CellML 2.0 Editors and Contributors', 'manual'),
-    ('index', 'index.tex', u'CellML Specification', u'CellML 2.0 Editors and Contributors', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of


### PR DESCRIPTION
The current PDF builder in our readthedocs configuration can't support more than one PDF at once.  This PR removes the line that's causing build errors; the PDF served will be only the formal normative spec.