### PR TITLE
i59 C.9.7 redundancy

### DIFF
--- a/reference/sectionC_interpretation.inc
+++ b/reference/sectionC_interpretation.inc
@@ -324,7 +324,7 @@ Interpretation of encapsulation
 
 #. The hidden set for a component *A* SHALL be the set of all components *B* where component *B* is not in the encapsulated set for component *A*, and component *B* is not the encapsulation parent of component *A*, and component *B* is not in the sibling set for component *A*.
 
-#. There MUST NOT be a :code:`connection` element such that the component referenced by the :code:`component_1` attribute is in the hidden set of the component referenced by the :code:`component_2` attribute, nor vice versa.
+#. For the avoidance of doubt, there MUST NOT be a :code:`connection` element such that the component referenced by the :code:`component_1` attribute is in the hidden set of the component referenced by the :code:`component_2` attribute, nor vice versa.
 
 .. marker_interpretation_of_encapsulation_end
 .. marker_interpretation_of_map_variables_start


### PR DESCRIPTION
Addresses #59
Rendered version here: https://cellml-specification-dev.readthedocs.io/en/i59_connections_in_sectionc/reference/formal_and_informative/specC09_interpretation_of_encapsulation.html

NB order of items in section C changed elsewhere - it's now:

1. Interpretation of imports
2. Units reference
3. Interpretation of units
4. Component reference
5. Variable reference
6. Interpretation of initial values
7. Effect of units on variables
8. Interpretation of mathematics
9. Interpretation of encapsulation
10. Interpretation of map_variables
11. Interpretation of variable resets

