### PR TITLE
I89 editors email

### DIFF
--- a/reference/sectionA_definitions.inc
+++ b/reference/sectionA_definitions.inc
@@ -27,7 +27,7 @@ Randall Britten,
 Poul Nielsen
 and David P. Nickerson
 
-**Contact:** help@physiomeproject.org
+**Contact:** editors@cellml.org
 
 **Preamble**
 


### PR DESCRIPTION
Addresses #89 by (re)changing the contact email address to editors@cellml.org