### PR TITLE
Remove libcellml refs

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# libCellML documentation build configuration file, created by
+# CellML specifications build configuration file, created by
 # sphinx-quickstart on Mon Jun  9 21:58:16 2014.
 #
 # This file is execfile()d with the current directory set to its

--- a/reference/informative/informB1_model3.rst
+++ b/reference/informative/informB1_model3.rst
@@ -15,4 +15,4 @@
     For more information about encapsulation, please refer to :ref:`The encapsulation element information item<specB_encapsulation>`.
 
     For more information and examples involving and explaining encapsulation, please refer to the :libcellml_tutorials:`Theory of a sodium channel <theory/theory_index.html>` page.
-    **TODO** put link to theory section in libCellML here?
+

--- a/reference/informative/informB3_import_units1.rst
+++ b/reference/informative/informB3_import_units1.rst
@@ -50,5 +50,3 @@
           </component>
         </model>
 
-      Note that libCellML uses some workarounds to avoid this kind of conflict.
-      Please click the :ref:`See libCellML implementation +<libcellml_import_units>` toggle for details.


### PR DESCRIPTION
Removes leftover references to libCellML, addresses [this comment](https://github.com/cellml/cellml-specification/pull/99#discussion_r399035193) and #102 