### PR TITLE
Identifier rules

### DIFF
--- a/src/reference/sectionA_definitions.inc
+++ b/src/reference/sectionA_definitions.inc
@@ -188,23 +188,11 @@ The following data representation formats are defined for use in this specificat
 
    .. container:: issue-data-repr-identifier-unicode
 
-      1. SHALL be a sequence of Unicode characters.
-
-   .. container:: issue-data-repr-identifier-latin-alphanum
-
-      2. SHALL NOT contain any characters except :ref:`Basic Latin alphanumeric characters<specA_basic_latin_alphanumeric_character>` and :ref:`Basic Latin underscores<specA_basic_latin_underscore>`.
-
-   .. container:: issue-data-repr-identifier-at-least-one-alphanum
-
-      3. SHALL contain at least one :ref:`alphabetic<specA_basic_latin_alphabetic_character>` character.
-
-   .. container:: issue-data-repr-identifier-begin-euro-num
-
-      4. SHALL NOT begin with a :ref:`numeral<specA_european_numeral>` or an :ref:`underscore<specA_basic_latin_underscore>`.
+      1. SHALL consist of a single :ref:`Basic Latin alphabetic character<specA_basic_latin_alphabetic_character>`, which MAY be followed by any combination of :ref:`Basic Latin alphanumeric characters<specA_basic_latin_alphanumeric_character>` and :ref:`Basic Latin underscores<specA_basic_latin_underscore>`.
 
    .. container:: issue-data-repr-identifier-identical
 
-      5. SHALL, when comparing two identifiers, be considered identical to another identifier if and only if both identifiers have identical sequences of characters.
+      2. SHALL, when comparing two identifiers, be considered identical to another identifier if and only if both identifiers are identical sequences of characters.
 
 .. marker_data_formats_1
 

--- a/src/reference/sectionA_definitions.inc
+++ b/src/reference/sectionA_definitions.inc
@@ -188,7 +188,7 @@ The following data representation formats are defined for use in this specificat
 
    .. container:: issue-data-repr-identifier-unicode
 
-      1. SHALL consist of a single :ref:`Basic Latin alphabetic character<specA_basic_latin_alphabetic_character>`, which MAY be followed by any combination of :ref:`Basic Latin alphanumeric characters<specA_basic_latin_alphanumeric_character>` and :ref:`Basic Latin underscores<specA_basic_latin_underscore>`.
+      1. SHALL consist of a single :ref:`Basic Latin alphabetic character<specA_basic_latin_alphabetic_character>`, which MAY be followed by any combination of :ref:`Basic Latin alphanumeric characters<specA_basic_latin_alphanumeric_character>` and/or :ref:`Basic Latin underscores<specA_basic_latin_underscore>`.
 
    .. container:: issue-data-repr-identifier-identical
 


### PR DESCRIPTION
- condensed identifier definition (#181 and #182 )

- the equality rule said "have identical sequences", which I think meant "have sequences that are entirely identical", but could be taken to mean "have identical sequences anywhere in the string", e.g. "hello_me" == "hello_you" since both have an identical sequence of characters ("hello_").
  - Someone might still want to argue that an identifier isn't a sequence itself so that "are" is wrong? Not me!