### PR TITLE
Consistently using 'identical' when comparing identifiers.

### DIFF
--- a/src/reference/sectionB_elements.inc
+++ b/src/reference/sectionB_elements.inc
@@ -153,7 +153,7 @@ A :code:`units` element information item (referred to in this specification as a
 
 .. container:: issue-units-standard
 
-   2. The value of the :code:`name` attribute MUST NOT be equal to the name of any of the units listed in the :ref:`Built-in units<table_built_in_units>` table.
+   2. The value of the :code:`name` attribute MUST NOT be identical to the name of any of the units listed in the :ref:`Built-in units<table_built_in_units>` table.
 
 .. container:: issue-units-child
 
@@ -179,7 +179,7 @@ A :code:`unit` element information item (referred to in this specification as a 
 
          1. For the purpose of the constraint in the next paragraph, the :code:`units` element inclusion digraph SHALL be defined as a conceptual digraph which SHALL contain one node for every :code:`units` element in the :ref:`CellML model<specA_cellml_model>`.
 
-            The :code:`units` element inclusion digraph SHALL contain an arc from :code:`units` element *A* to :code:`units` element *B* if and only if :code:`units` element *A* contains a :code:`unit` element with a :code:`units` attribute value that is equal to the :code:`name` attribute value of :code:`units` element *B*.
+            The :code:`units` element inclusion digraph SHALL contain an arc from :code:`units` element *A* to :code:`units` element *B* if and only if :code:`units` element *A* contains a :code:`unit` element with a :code:`units` attribute value that is identical to the :code:`name` attribute value of :code:`units` element *B*.
 
       .. container:: issue-unit-circular-ref
 
@@ -486,7 +486,7 @@ A :code:`connection` element information item (referred to in this specification
 
 .. container:: issue-todo
 
-   3. The value of the :code:`component_1` attribute MUST NOT be equal to the value of the :code:`component_2` attribute.
+   3. The value of the :code:`component_1` attribute MUST NOT be identical to the value of the :code:`component_2` attribute.
 
 .. marker_connection_3
 

--- a/src/reference/sectionC_interpretation.inc
+++ b/src/reference/sectionC_interpretation.inc
@@ -35,11 +35,11 @@ A "units reference" is an attribute value that specifies the physical units a va
 
 #. The units identified by a units reference SHALL be determined as follows:
 
-   #. If the units reference is equal to a value in the "Name" column of the :ref:`Built-in units table<table_built_in_units>`, then it SHALL refer to the corresponding built-in units from the same of the table.
+   #. If the units reference is identical to a value in the "Name" column of the :ref:`Built-in units table<table_built_in_units>`, then it SHALL refer to the corresponding built-in units from the same of the table.
 
-   #. If the units reference is equal to the value of the :code:`name` attribute of a :code:`units` element in the same infoset, then it SHALL refer to the units specified by that element.
+   #. If the units reference is identical to the value of the :code:`name` attribute of a :code:`units` element in the same infoset, then it SHALL refer to the units specified by that element.
 
-   #. If the units reference is equal to the value of the :code:`name` attribute of an :code:`import units` element in the same infoset, then it SHALL refer to units from the infoset defined by the :code:`import units` element (see :ref:`Interpretation of ``import`` elements`<specC_interpreation_of_imports>`).
+   #. If the units reference is identical to the value of the :code:`name` attribute of an :code:`import units` element in the same infoset, then it SHALL refer to units from the infoset defined by the :code:`import units` element (see :ref:`Interpretation of ``import`` elements`<specC_interpreation_of_imports>`).
       The units specified SHALL then be determined by treating the value of the :code:`units_ref` attribute on the :code:`import units` element as a units reference within the imported infoset.
       If necessary, this rule SHALL be applied recursively.
 
@@ -238,9 +238,9 @@ A "component reference" is an attribute value that specifies a CellML component.
 
 #. The component identifier by a component reference SHALL be determined as follows:
 
-   #. If the component reference is equal to the value of the :code:`name` attribute of a :code:`component` element in the same infoset, then it SHALL refer to the units specified by that element.
+   #. If the component reference is identical to the value of the :code:`name` attribute of a :code:`component` element in the same infoset, then it SHALL refer to the units specified by that element.
 
-   #. If the component reference is equal to the value of the :code:`name` attribute of an :code:`import component` element in the same infoset, then it SHALL refer to a component from the infoset defined by the :code:`import component` element (see :ref:`Interpretation of ``import`` elements`<specC_interpreation_of_imports>`).
+   #. If the component reference is identical to the value of the :code:`name` attribute of an :code:`import component` element in the same infoset, then it SHALL refer to a component from the infoset defined by the :code:`import component` element (see :ref:`Interpretation of ``import`` elements`<specC_interpreation_of_imports>`).
       The component specified SHALL then be determined by treating the value of the :code:`component_ref` attribute on the :code:`import component` element as a component reference within the imported infoset.
       If necessary, this rule SHALL be applied recursively.
 


### PR DESCRIPTION
Closes #237.