### PR TITLE
Encapsulation loops

### DIFF
--- a/src/reference/sectionB_elements.inc
+++ b/src/reference/sectionB_elements.inc
@@ -454,6 +454,8 @@ A :code:`component_ref` element information item (referred to in this specificat
 
       The value of the :code:`component` attribute MUST be a valid component reference, as defined in the section :ref:`Component references<specC_component_reference>`.
 
+      The value of the :code:`component` attribute MUST NOT be identical to the value of the :code:`component` attribute on any other :code:`component_ref` element in the :ref:`CellML infoset<specA_cellml_infoset>`.
+
 .. container:: issue-component-ref-child
 
    2. Every :code:`component_ref` element MAY in turn contain one or more :code:`component_ref` element children.

--- a/src/reference/sectionC_interpretation.inc
+++ b/src/reference/sectionC_interpretation.inc
@@ -328,8 +328,7 @@ Interpretation of ``math`` elements
 Interpretation of ``encapsulation`` elements
 --------------------------------------------
 
-1. For the purposes of this specification, there SHALL be a "conceptual encapsulation digraph" in which there is EXACTLY one node for every component in the :ref:`CellML model<specA_cellml_model>`.
-   Therefore the encapsulation digraph will not contain any loops.
+1. For the purposes of this specification, there SHALL be a conceptual "encapsulation digraph" in which there is exactly one node for every component in the :ref:`CellML model<specA_cellml_model>`.
 
 2. Where a :code:`component_ref` element appears as a child of another :code:`component_ref` element, there SHALL be an arc in the encapsulation digraph, and that arc SHALL be from the node corresponding to the component referenced by the parent :code:`component_ref` element, and to the node corresponding to the component referenced by the child :code:`component_ref` element.
 


### PR DESCRIPTION
Added rule saying the component referenced by a component_ref element must be unique, which prevents cycles in the encapsulation digraph.

See #261