### PR TITLE
Changed 'see X' links from `:ref:` to `:numref:`

### DIFF
--- a/src/reference/sectionB_elements.inc
+++ b/src/reference/sectionB_elements.inc
@@ -76,7 +76,7 @@ An :code:`import` element information item (referred to in this specification as
 
 .. container:: issue-import-circular
 
-   3. Any :ref:`CellML infoset<specA_cellml_infoset>` imported, directly or indirectly, by the imported CellML infoset MUST NOT be semantically equivalent to the importing CellML infoset (see :ref:`Semantically equivalent CellML infosets <specA_semantic_equivalence>`).
+   3. Any :ref:`CellML infoset<specA_cellml_infoset>` imported, directly or indirectly, by the imported CellML infoset MUST NOT be semantically equivalent to the importing CellML infoset (see :numref:`%s. Non-specific information items<specA_semantic_equivalence>`).
 
 .. marker_import_end
 .. marker_import_units_start
@@ -153,7 +153,7 @@ A :code:`units` element information item (referred to in this specification as a
 
 .. container:: issue-units-standard
 
-   2. The value of the :code:`name` attribute MUST NOT be identical to the name of any of the units listed in the :ref:`Built-in units<table_built_in_units>` table.
+   2. The value of the :code:`name` attribute MUST NOT be identical to the name of any of the units listed in the :ref:`Built-in units table<table_built_in_units>` (see :numref:`%s. Units references<specC_units_reference>`).
 
 .. container:: issue-units-child
 
@@ -173,7 +173,7 @@ A :code:`unit` element information item (referred to in this specification as a 
 
    1. Every :code:`unit` element MUST contain a :code:`units` attribute.
 
-      The value of the :code:`units` attribute MUST be a valid units reference, as defined in the section :ref:`Units references<specC_units_reference>`.
+      The value of the :code:`units` attribute MUST be a valid units reference, as defined in :numref:`%s. Units references<specC_units_reference>`.
 
       .. container:: issue-unit-digraph
 
@@ -193,7 +193,7 @@ A :code:`unit` element information item (referred to in this specification as a 
 
       .. container:: issue-unit-prefix
 
-         1. The :code:`prefix` attribute. If present, the value of the attribute MUST meet the constraints specified in the :ref:`Interpretation of units <specC_interpretation_of_units>` section.
+         1. The :code:`prefix` attribute. If present, the value of the attribute MUST meet the constraints specified in :numref:`%s. Interpretation of units elements <specC_interpretation_of_units>`.
 
       .. container:: issue-unit-multiplier
 
@@ -259,7 +259,7 @@ A :code:`variable` element information item (referred to in this specification a
    .. container:: issue-variable-units
 
       2. The :code:`units` attribute.
-         The value of the :code:`units` attribute MUST be a valid units reference, as defined in the section :ref:`Units references<specC_units_reference>`.
+         The value of the :code:`units` attribute MUST be a valid units reference, as defined in :numref:`%s. Units references<specC_units_reference>`.
 
 2. Every :code:`variable` element MAY contain one or more of the following attributes:
 
@@ -271,7 +271,7 @@ A :code:`variable` element information item (referred to in this specification a
    .. container:: issue-variable-initial-value
 
       2. The :code:`initial_value` attribute.
-         If the attribute is present, it MUST meet the requirements described by the :ref:`Interpretation of initial values<specC_interpretation_of_initial_values>` section.
+         If the attribute is present, it MUST meet the requirements described by :numref:`%s. Interpretation of initial_value attributes<specC_interpretation_of_initial_values>`.
 
 .. marker_variable_end
 .. marker_reset_start
@@ -288,19 +288,19 @@ A :code:`reset` element information item (referred to in this specification as a
    .. container:: issue-reset-variable-reference
 
       1. The :code:`variable` attribute.
-         The value of the :code:`variable` attribute MUST be a valid variable reference, as defined in the section :ref:`Variable references<specC_variable_reference>`.
+         The value of the :code:`variable` attribute MUST be a valid variable reference, as defined in :numref:`%s. Variable references<specC_variable_reference>`.
 
    .. container:: issue-reset-test-variable-reference
 
       2. The :code:`test_variable` attribute.
-         The value of the :code:`test_variable` attribute MUST be a valid variable reference, as defined in the section :ref:`Variable references<specC_variable_reference>`.
+         The value of the :code:`test_variable` attribute MUST be a valid variable reference, as defined in :numref:`%s. Variable references<specC_variable_reference>`.
 
    .. container:: issue-reset-order
 
       3. The :code:`order` attribute.
          The value of the :code:`order` attribute MUST be an :ref:`integer string<specA_integer>`.
 
-         The value of the :code:`order` attribute MUST be unique for all :code:`reset` elements with :code:`variable` attributes that reference variables in the same equivalent variable set (see :ref:`Interpretation of map_variables<specC_interpretation_of_map_variables>`).
+         The value of the :code:`order` attribute MUST be unique for all :code:`reset` elements with :code:`variable` attributes that reference variables in the same equivalent variable set (see :numref:`%s. Interpretation of map_variables elements<specC_interpretation_of_map_variables>`).
 
 .. container:: issue-reset-child
 
@@ -360,13 +360,13 @@ A :code:`math` element information item (referred to in this specification as a 
 
 .. container:: issue-math-child
 
-   2. Each element child of a :code:`math` element MUST have an element-type name that is listed in the :ref:`Supported MathML Elements<table_supported_mathml_elements>` table.
+   2. Each element child of a :code:`math` element MUST have an element-type name that is listed in the :ref:`Supported MathML Elements table<table_supported_mathml_elements>`.
 
 .. marker_math_2
 
 .. container:: issue-math-ci-variable-reference
 
-   3. The contents of a MathML :code:`ci` element MUST be a valid variable reference, as defined in the section :ref:`Variable references<specC_variable_reference>`.
+   3. The contents of a MathML :code:`ci` element MUST be a valid variable reference, as defined in :numref:`%s. Variable references<specC_variable_reference>`.
 
 .. marker_math_3
 
@@ -374,7 +374,7 @@ A :code:`math` element information item (referred to in this specification as a 
 
    4. A MathML :code:`cn` element MUST have an attribute in the :ref:`CellML namespace<specA_cellml_namespace>`, with a local name equal to :code:`units`.
 
-      The value of the :code:`units` attribute MUST be a valid units reference, as defined in the section :ref:`Units references<specC_units_reference>`.
+      The value of the :code:`units` attribute MUST be a valid units reference, as defined in :numref:`%s. Units references<specC_units_reference>`.
 
 .. container:: issue-math-cn-type
 
@@ -452,7 +452,7 @@ A :code:`component_ref` element information item (referred to in this specificat
 
    1. Every :code:`component_ref` element MUST contain a :code:`component` attribute.
 
-      The value of the :code:`component` attribute MUST be a valid component reference, as defined in the section :ref:`Component references<specC_component_reference>`.
+      The value of the :code:`component` attribute MUST be a valid component reference, as defined in :numref:`%s. Component references<specC_component_reference>`.
 
 .. container:: issue-component-ref-child
 
@@ -472,7 +472,7 @@ A :code:`connection` element information item (referred to in this specification
 
    1. Each :code:`connection` element MUST contain a :code:`component_1` attribute.
 
-      The value of the :code:`component_1` attribute MUST be a valid component reference, as defined in the section :ref:`Component references<specC_component_reference>`.
+      The value of the :code:`component_1` attribute MUST be a valid component reference, as defined in :numref:`%s. Component references<specC_component_reference>`.
 
 .. marker_connection_1
 
@@ -480,7 +480,7 @@ A :code:`connection` element information item (referred to in this specification
 
    2. Each :code:`connection` element MUST contain a :code:`component_2` attribute.
 
-      The value of the :code:`component_2` attribute MUST be a valid component reference, as defined in the section :ref:`Component references<specC_component_reference>`.
+      The value of the :code:`component_2` attribute MUST be a valid component reference, as defined in :numref:`%s. Component references<specC_component_reference>`.
 
 .. marker_connection_2
 
@@ -514,7 +514,7 @@ A :code:`map_variables` element information item (referred to in this specificat
 
    1. Each :code:`map_variables` element MUST contain a :code:`variable_1` attribute.
 
-      The value of the :code:`variable_1` attribute MUST be a valid variable reference, as defined in the section :ref:`Variable references<specC_variable_reference>`.
+      The value of the :code:`variable_1` attribute MUST be a valid variable reference, as defined in :numref:`%s. Variable references<specC_variable_reference>`.
 
 .. marker_map_variables_1
 
@@ -522,7 +522,7 @@ A :code:`map_variables` element information item (referred to in this specificat
 
    2. Each :code:`map_variables` element MUST contain a :code:`variable_2` attribute.
 
-      The value of the :code:`variable_2` attribute MUST be a valid variable reference, as defined in the section :ref:`Variable references<specC_variable_reference>`.
+      The value of the :code:`variable_2` attribute MUST be a valid variable reference, as defined in :numref:`%s. Variable references<specC_variable_reference>`.
 
 .. marker_map_variables_2
 

--- a/src/reference/sectionC_interpretation.inc
+++ b/src/reference/sectionC_interpretation.inc
@@ -13,7 +13,7 @@ Interpretation of ``import`` elements
 
 #. When determining the :ref:`equivalent variable set<specC_equivalent_variable_set>` of a variable in an imported component:
 
-   #. connections defined in the importing infoset shall be handled as described in :ref:`Interpretation of map_variables<specC_interpretation_of_map_variables>`.
+   #. connections defined in the importing infoset shall be handled as described in :numref:`%s. Interpretation of map_variables elements<specC_interpretation_of_map_variables>`.
 
    #. connections defined in the imported infoset shall be handled as follows:
 
@@ -39,7 +39,7 @@ A "units reference" is an attribute value that specifies the physical units a va
 
    #. If the units reference is identical to the value of the :code:`name` attribute of a :code:`units` element in the same infoset, then it SHALL refer to the units specified by that element.
 
-   #. If the units reference is identical to the value of the :code:`name` attribute of an :code:`import units` element in the same infoset, then it SHALL refer to units from the infoset defined by the :code:`import units` element (see :ref:`Interpretation of import elements`<specC_interpretation_of_imports>`).
+   #. If the units reference is identical to the value of the :code:`name` attribute of an :code:`import units` element in the same infoset, then it SHALL refer to units from the infoset defined by the :code:`import units` element (see :numref:`%s. Interpretation of import elements`<specC_interpretation_of_imports>`).
       The units specified SHALL then be determined by treating the value of the :code:`units_ref` attribute on the :code:`import units` element as a units reference within the imported infoset.
       If necessary, this rule SHALL be applied recursively.
 
@@ -165,9 +165,9 @@ Interpretation of ``units`` elements
 
 .. marker_interpretation_of_units_1
 
-.. specC_irreducible_units:
+.. _specC_irreducible_units:
 
-2. For the purposes of this specification, the "irreducible units" of a model SHALL consist of 1) the units defined in a model that are not defined in terms of other units (i.e. the set of :code:`units` elements in the :ref:`CellML model<specA_cellml_model>` which have no :code:`unit` child elements), and 2) built-in irreducible units (those built-in units with "-" in the "Unit Reduction" column of the :ref:`Built-in units<table_built_in_units>` table) referenced by variables or other units in the model.
+2. For the purposes of this specification, the "irreducible units" of a model SHALL consist of 1) the units defined in a model that are not defined in terms of other units (i.e. the set of :code:`units` elements in the :ref:`CellML model<specA_cellml_model>` which have no :code:`unit` child elements), and 2) built-in irreducible units (those built-in units with "-" in the "Unit Reduction" column of the :ref:`Built-in units table<table_built_in_units>`) referenced by variables or other units in the model.
 
 .. marker_interpretation_of_units_2
 
@@ -182,7 +182,7 @@ Interpretation of ``units`` elements
 
       1. Where the :ref:`units reference<specC_units_reference>` of the :code:`unit` child element is to a single unit which is an irreducible unit, then the set of tuples SHALL have a single member, which SHALL consist of the name of the irreducible unit being referenced and the exponent 1.0.
 
-      2. Where the units reference of the :code:`unit` child element is to built-in units other than an :ref:`irreducible unit<specC_irreducible_units>`, then the tuples SHALL be derived directly from the :ref:`Built-in units<table_built_in_units>` table.
+      2. Where the units reference of the :code:`unit` child element is to built-in units other than an :ref:`irreducible unit<specC_irreducible_units>`, then the tuples SHALL be derived directly from the :ref:`Built-in units table<table_built_in_units>`.
          Specifically, the set of tuples SHALL consist of the tuples given in the "Unit reduction tuple set" column of the row for which the value in the "Name" column matches the name of the units reference.
 
       3. Where the units reference of the :code:`unit` child element is to a unit which is neither built-in, nor an irreducible unit, the set of tuples SHALL be defined recursively as the set of tuples for the :code:`units` element so referenced.
@@ -242,7 +242,7 @@ A "component reference" is an attribute value that specifies a CellML component.
 
    #. If the component reference is identical to the value of the :code:`name` attribute of a :code:`component` element in the same infoset, then it SHALL refer to the units specified by that element.
 
-   #. If the component reference is identical to the value of the :code:`name` attribute of an :code:`import component` element in the same infoset, then it SHALL refer to a component from the infoset defined by the :code:`import component` element (see :ref:`Interpretation of import elements<specC_interpretation_of_imports>`).
+   #. If the component reference is identical to the value of the :code:`name` attribute of an :code:`import component` element in the same infoset, then it SHALL refer to a component from the infoset defined by the :code:`import component` element (see :numref:`%s. Interpretation of import elements<specC_interpretation_of_imports>`).
       The component specified SHALL then be determined by treating the value of the :code:`component_ref` attribute on the :code:`import component` element as a component reference within the imported infoset.
       If necessary, this rule SHALL be applied recursively.
 
@@ -296,7 +296,7 @@ Interpretation of ``initial_value`` attributes
 Effect of ``units`` on a ``variable``
 -------------------------------------
 
-#. The target of the :code:`units` attribute on a variable is referred to as the "variable units", and the corresponding unit reduction (see :ref:`Interpretation of units<specC_interpretation_of_units>`) is referred to as the "variable unit reduction".
+#. The target of the :code:`units` attribute on a variable is referred to as the "variable units", and the corresponding unit reduction (see :numref:`%s. Interpretation of units elements<specC_interpretation_of_units>`) is referred to as the "variable unit reduction".
 
 .. marker_effect_of_units_on_variables_end
 .. marker_interpretation_of_mathematics_start
@@ -311,9 +311,9 @@ Interpretation of ``math`` elements
 
    #. All :code:`component` elements in the top-level :ref:`CellML infoset<specA_cellml_infoset>` for the :ref:`CellML model<specA_cellml_model>`;
 
-   #. All :code:`component` elements referenced by :code:`import component` elements (see :ref:`The import component element <specC_component_reference>`) in the top-level CellML infoset; and
+   #. All :code:`component` elements referenced by :code:`import component` elements (see :numref:`%s. Interpretation of import elements<specC_interpretation_of_imports>`) in the top-level CellML infoset; and
 
-   #. All :code:`component` elements which are descendants in the encapsulation digraph (see :ref:`Interpretation of encapsulation <specC_interpretation_of_encapsulation>`) of a pertinent :code:`component` element.
+   #. All :code:`component` elements which are descendants in the encapsulation digraph (see :numref:`%s. Interpretation of encapsulation elements<specC_interpretation_of_encapsulation>`) of a pertinent :code:`component` element.
 
 #. Every MathML element in the CellML model which appears as a direct child of a MathML :code:`math` element, which in turn appears as a child of a pertinent :code:`component` element, SHALL be treated, in terms of the semantics of the mathematical model, as a statement which holds true unconditionally.
 
@@ -414,11 +414,11 @@ Interpretation of ``map_variables`` elements
 
 .. marker_interpretation_of_map_variables_4
 
-9.  For each :code:`map_variables` element present in the CellML model, the variable unit reduction (see :ref:`Effect of units on variables <specC_effect_of_units_on_variables>` ) of variable *A* MUST have an identical set of tuples to the variable unit reduction of variable *B*.
+9.  For each :code:`map_variables` element present in the CellML model, the variable unit reduction (see :numref:`%s. Effect of units on variables<specC_effect_of_units_on_variables>` ) of variable *A* MUST have an identical set of tuples to the variable unit reduction of variable *B*.
     Two sets of tuples SHALL be considered identical if all of the tuples from each set are present in the other, or if both sets are empty.
     Two tuples are considered identical if and only if both the name and exponent value of each tuple are equivalent.
 
-10.  Tuples differing by a multiplying factor in their unit reduction MUST be taken into account when interpreting the numerical values of the variables (see :ref:`Interpretation of units<specC_interpretation_of_units>`).
+10.  Tuples differing by a multiplying factor in their unit reduction MUST be taken into account when interpreting the numerical values of the variables (see :numref:`%s. Interpretation of units elements<specC_interpretation_of_units>`).
 
 .. marker_interpretation_of_map_variables_5
 .. _specC_equivalent_variable_set:
@@ -440,7 +440,7 @@ Interpretation of ``reset`` elements
 
 #. Each :code:`reset` element describes a change to be applied to the reset variable when specified conditions are met during the simulation of the model.
 
-#. All :code:`reset` elements SHALL be considered sequentially for the equivalent variable set (see :ref:`Interpretation of map_variables<specC_interpretation_of_map_variables>`) to which the reset variable belongs.
+#. All :code:`reset` elements SHALL be considered sequentially for the equivalent variable set (see :numref:`%s. Interpretation of map_variables elements<specC_interpretation_of_map_variables>`) to which the reset variable belongs.
    The sequence SHALL be determined by the value of the reset element’s :code:`order` attribute, lowest (least positive / most negative) having priority.
 
 #. The condition under which a reset occurs SHALL be defined by the equality of evaluation of the test variable and the evaluation of the MathML expression encoded in the :code:`test_value`.

--- a/src/reference/sectionC_interpretation.inc
+++ b/src/reference/sectionC_interpretation.inc
@@ -414,7 +414,7 @@ Interpretation of ``map_variables`` elements
 
 .. marker_interpretation_of_map_variables_4
 
-9.  For each :code:`map_variables` element present in the CellML model, the variable unit reduction (see :numref:`%s. Effect of units on variables<specC_effect_of_units_on_variables>` ) of variable *A* MUST have an identical set of tuples to the variable unit reduction of variable *B*.
+9.  For each :code:`map_variables` element present in the CellML model, the variable unit reduction (see :numref:`%s. Effect of units on variables<specC_effect_of_units_on_variables>`) of variable *A* MUST have an identical set of tuples to the variable unit reduction of variable *B*.
     Two sets of tuples SHALL be considered identical if all of the tuples from each set are present in the other, or if both sets are empty.
     Two tuples are considered identical if and only if both the name and exponent value of each tuple are equivalent.
 

--- a/src/reference/sectionC_interpretation.inc
+++ b/src/reference/sectionC_interpretation.inc
@@ -168,11 +168,11 @@ Interpretation of ``units`` elements
 .. _specC_irreducible_units:
 
 2. For the purposes of this specification, the "irreducible units" of a model SHALL consist of:
-  
+
    1. The units defined in a model that are not defined in terms of other units (i.e. the set of :code:`units` elements in the :ref:`CellML model<specA_cellml_model>` which have no :code:`unit` child elements).
 
    2. The built-in irreducible units (those built-in units with "-" in the "Unit Reduction" column of the :ref:`Built-in units table<table_built_in_units>`) referenced by variables or other units in the model.
-   
+
 .. marker_interpretation_of_units_2
 
 3. The "unit reduction" is a conceptual property of :code:`units` elements.


### PR DESCRIPTION
Fixes #239.

There's a lot of links that aren't important enough to interrupt the flow of the text with a section number, so have left them as they are.

Also links to tables for some reason can't be numrefs, so haven't touched those.