### PR TITLE
I280 numbering references

### DIFF
--- a/src/conf.py
+++ b/src/conf.py
@@ -145,6 +145,9 @@ extlinks = {
     'sphinx': ('http://sphinx-doc.org/%s', ''),
     'swig': ('http://www.swig.org/%s', ''),
     'unicode': ('http://www.fileformat.info/info/unicode/char/%s/index.htm', 'U+'),
+
+    # These should be identical: one for links, one for full URL display
+    'unicode13':         ('https://www.unicode.org/versions/Unicode13.0.0%s', ''),
     'unicode13_display': ('https://www.unicode.org/versions/Unicode13.0.0%s', None),
 
     # These should be identical: one for links, one for full URL display

--- a/src/reference/sectionA_definitions.inc
+++ b/src/reference/sectionA_definitions.inc
@@ -7,9 +7,9 @@
 Terminology
 -----------
 
-The keywords "MUST", "MUST NOT", "SHALL", "SHALL NOT", and "MAY" in this document are to be interpreted as described in :rfc2119:`RFC 2119 <>` [Ref_4]_.
+The keywords "MUST", "MUST NOT", "SHALL", "SHALL NOT", and "MAY" in this document are to be interpreted as described in :rfc2119:`RFC 2119 <>` [:ref:`4<ref_rfc2119>`].
 
-The key phrase "information item", as well as any specific type of information item such as an "element information item", are to be interpreted as described in :xml_infoset:`XML Information Set <>` [Ref_6]_.
+The key phrase "information item", as well as any specific type of information item such as an "element information item", are to be interpreted as described in :xml_infoset:`XML Information Set <>` [:ref:`6<ref_xml_infoset>`].
 
 .. _specA_cellml_infoset:
 
@@ -26,7 +26,7 @@ In this specification, the topmost CellML infoset in a hierarchy is referred to 
 .. _specA_namespace:
 
 **Namespace:**
-An XML namespace, as defined in :xml_namespace_1_1:`Namespaces in XML 1.1 <>` [Ref_3]_.
+An XML namespace, as defined in :xml_namespace_1_1:`Namespaces in XML 1.1 <>` [:ref:`3<xml_namespace_1_1>`].
 
 .. _specA_cellml_namespace:
 
@@ -50,7 +50,7 @@ Any information item in the :ref:`CellML namespace<specA_cellml_namespace>`.
 .. _specA_basic_latin_alphabetical_character:
 
 **Basic Latin alphabetical character:**
-A Unicode [Ref_5]_ character in the range :unicode:`0041` to :unicode:`005A` or in the range :unicode:`0061` to :unicode:`007A`.
+A Unicode [:ref:`5<ref_unicode>`] character in the range :unicode:`0041` to :unicode:`005A` or in the range :unicode:`0061` to :unicode:`007A`.
 
 .. _specA_digit:
 
@@ -98,7 +98,7 @@ CellML information sets
 CellML and XML
 ~~~~~~~~~~~~~~
 
-#. Every :ref:`CellML infoset<specA_cellml_infoset>` SHALL be represented in an XML information set which conforms with the well-formedness requirements of :xml_1_1:`XML 1.1 <>` [Ref_1]_.
+#. Every :ref:`CellML infoset<specA_cellml_infoset>` SHALL be represented in an XML information set which conforms with the well-formedness requirements of :xml_1_1:`XML 1.1 <>` [:ref:`1<ref_xml_1_1>`].
 
 #. In this document, the remaining provisions relating to CellML infosets SHALL be interpreted as additional constraints on the XML information set represented by a CellML infoset.
 
@@ -175,7 +175,7 @@ XML ID Attributes
 ~~~~~~~~~~~~~~~~~
 
 #. Any element information item in the :ref:`CellML namespace<specA_cellml_namespace>` MAY contain an attribute with local name :code:`id.`
-   This attribute SHALL be treated as having attribute type ID, as defined in :xml_1_1:`section 3.3.1 <#sec-attribute-types>` of :xml_1_1:`XML 1.1 <>` [Ref_1]_.
+   This attribute SHALL be treated as having attribute type ID, as defined in :xml_1_1:`section 3.3.1 <#sec-attribute-types>` of :xml_1_1:`XML 1.1 <>` [:ref:`1<ref_xml_1_1>`].
 
 .. marker_cellml_information_sets_end
 .. marker_data_formats_start

--- a/src/reference/sectionA_definitions.inc
+++ b/src/reference/sectionA_definitions.inc
@@ -7,7 +7,7 @@
 Terminology
 -----------
 
-The keywords "MUST", "MUST NOT", "SHALL", "SHALL NOT", and "MAY" in this document are to be interpreted as described in :rfc2119:`RFC 2119 <>`[Ref_4]_.
+The keywords "MUST", "MUST NOT", "SHALL", "SHALL NOT", and "MAY" in this document are to be interpreted as described in :rfc2119:`RFC 2119 <>` [Ref_4]_.
 
 The key phrase "information item", as well as any specific type of information item such as an "element information item", are to be interpreted as described in :xml_infoset:`XML Information Set <>` [Ref_6]_.
 

--- a/src/reference/sectionA_definitions.inc
+++ b/src/reference/sectionA_definitions.inc
@@ -26,7 +26,7 @@ In this specification, the topmost CellML infoset in a hierarchy is referred to 
 .. _specA_namespace:
 
 **Namespace:**
-An XML namespace, as defined in :xml_namespace_1_1:`Namespaces in XML 1.1 <>` [:ref:`3<xml_namespace_1_1>`].
+An XML namespace, as defined in :xml_namespace_1_1:`Namespaces in XML 1.1 <>` [:ref:`3<ref_xml_namespace_1_1>`].
 
 .. _specA_cellml_namespace:
 

--- a/src/reference/sectionA_definitions.inc
+++ b/src/reference/sectionA_definitions.inc
@@ -50,7 +50,7 @@ Any information item in the :ref:`CellML namespace<specA_cellml_namespace>`.
 .. _specA_basic_latin_alphabetical_character:
 
 **Basic Latin alphabetical character:**
-A Unicode [:ref:`5<ref_unicode>`] character in the range :unicode:`0041` to :unicode:`005A` or in the range :unicode:`0061` to :unicode:`007A`.
+A :unicode13:`Unicode <>` [:ref:`5<ref_unicode>`] character in the range :unicode:`0041` to :unicode:`005A` or in the range :unicode:`0061` to :unicode:`007A`.
 
 .. _specA_digit:
 

--- a/src/reference/sectionA_definitions.inc
+++ b/src/reference/sectionA_definitions.inc
@@ -7,9 +7,9 @@
 Terminology
 -----------
 
-The keywords "MUST", "MUST NOT", "SHALL", "SHALL NOT", and "MAY" in this document are to be interpreted as described in :rfc2119:`RFC 2119 <>`[ref_rfc2119]_.
+The keywords "MUST", "MUST NOT", "SHALL", "SHALL NOT", and "MAY" in this document are to be interpreted as described in :rfc2119:`RFC 2119 <>`[Ref_4]_.
 
-The key phrase "information item", as well as any specific type of information item such as an "element information item", are to be interpreted as described in :xml_infoset:`XML Information Set <>` [ref_xml_infoset]_.
+The key phrase "information item", as well as any specific type of information item such as an "element information item", are to be interpreted as described in :xml_infoset:`XML Information Set <>` [Ref_6]_.
 
 .. _specA_cellml_infoset:
 
@@ -26,7 +26,7 @@ In this specification, the topmost CellML infoset in a hierarchy is referred to 
 .. _specA_namespace:
 
 **Namespace:**
-An XML namespace, as defined in :xml_namespace_1_1:`Namespaces in XML 1.1 <>` [ref_xml_namespace_1_1]_.
+An XML namespace, as defined in :xml_namespace_1_1:`Namespaces in XML 1.1 <>` [Ref_3]_.
 
 .. _specA_cellml_namespace:
 
@@ -50,7 +50,7 @@ Any information item in the :ref:`CellML namespace<specA_cellml_namespace>`.
 .. _specA_basic_latin_alphabetical_character:
 
 **Basic Latin alphabetical character:**
-A Unicode [ref_unicode]_ character in the range :unicode:`0041` to :unicode:`005A` or in the range :unicode:`0061` to :unicode:`007A`.
+A Unicode [Ref_5]_ character in the range :unicode:`0041` to :unicode:`005A` or in the range :unicode:`0061` to :unicode:`007A`.
 
 .. _specA_digit:
 
@@ -98,7 +98,7 @@ CellML information sets
 CellML and XML
 ~~~~~~~~~~~~~~
 
-#. Every :ref:`CellML infoset<specA_cellml_infoset>` SHALL be represented in an XML information set which conforms with the well-formedness requirements of :xml_1_1:`XML 1.1 <>` [ref_xml_1_1]_.
+#. Every :ref:`CellML infoset<specA_cellml_infoset>` SHALL be represented in an XML information set which conforms with the well-formedness requirements of :xml_1_1:`XML 1.1 <>` [Ref_1]_.
 
 #. In this document, the remaining provisions relating to CellML infosets SHALL be interpreted as additional constraints on the XML information set represented by a CellML infoset.
 
@@ -175,7 +175,7 @@ XML ID Attributes
 ~~~~~~~~~~~~~~~~~
 
 #. Any element information item in the :ref:`CellML namespace<specA_cellml_namespace>` MAY contain an attribute with local name :code:`id.`
-   This attribute SHALL be treated as having attribute type ID, as defined in :xml_1_1:`section 3.3.1 <#sec-attribute-types>` of :xml_1_1:`XML 1.1 <>` [ref_xml_1_1]_.
+   This attribute SHALL be treated as having attribute type ID, as defined in :xml_1_1:`section 3.3.1 <#sec-attribute-types>` of :xml_1_1:`XML 1.1 <>` [Ref_1]_.
 
 .. marker_cellml_information_sets_end
 .. marker_data_formats_start

--- a/src/reference/sectionA_definitions.inc
+++ b/src/reference/sectionA_definitions.inc
@@ -7,9 +7,9 @@
 Terminology
 -----------
 
-The keywords "MUST", "MUST NOT", "SHALL", "SHALL NOT", and "MAY" in this document are to be interpreted as described in :rfc2119:`RFC 2119 <>`.
+The keywords "MUST", "MUST NOT", "SHALL", "SHALL NOT", and "MAY" in this document are to be interpreted as described in :rfc2119:`RFC 2119 <>`[ref_rfc2119]_.
 
-The key phrase "information item", as well as any specific type of information item such as an "element information item", are to be interpreted as described in :xml_infoset:`XML Information Set <>`.
+The key phrase "information item", as well as any specific type of information item such as an "element information item", are to be interpreted as described in :xml_infoset:`XML Information Set <>` [ref_xml_infoset]_.
 
 .. _specA_cellml_infoset:
 
@@ -26,7 +26,7 @@ In this specification, the topmost CellML infoset in a hierarchy is referred to 
 .. _specA_namespace:
 
 **Namespace:**
-An XML namespace, as defined in :xml_namespace_1_1:`Namespaces in XML 1.1 <>`.
+An XML namespace, as defined in :xml_namespace_1_1:`Namespaces in XML 1.1 <>` [ref_xml_namespace_1_1]_.
 
 .. _specA_cellml_namespace:
 
@@ -50,7 +50,7 @@ Any information item in the :ref:`CellML namespace<specA_cellml_namespace>`.
 .. _specA_basic_latin_alphabetical_character:
 
 **Basic Latin alphabetical character:**
-A Unicode character in the range :unicode:`0041` to :unicode:`005A` or in the range :unicode:`0061` to :unicode:`007A`.
+A Unicode [ref_unicode]_ character in the range :unicode:`0041` to :unicode:`005A` or in the range :unicode:`0061` to :unicode:`007A`.
 
 .. _specA_digit:
 
@@ -98,7 +98,7 @@ CellML information sets
 CellML and XML
 ~~~~~~~~~~~~~~
 
-#. Every :ref:`CellML infoset<specA_cellml_infoset>` SHALL be represented in an XML information set which conforms with the well-formedness requirements of :xml_1_1:`XML 1.1 <>`.
+#. Every :ref:`CellML infoset<specA_cellml_infoset>` SHALL be represented in an XML information set which conforms with the well-formedness requirements of :xml_1_1:`XML 1.1 <>` [ref_xml_1_1]_.
 
 #. In this document, the remaining provisions relating to CellML infosets SHALL be interpreted as additional constraints on the XML information set represented by a CellML infoset.
 
@@ -175,7 +175,7 @@ XML ID Attributes
 ~~~~~~~~~~~~~~~~~
 
 #. Any element information item in the :ref:`CellML namespace<specA_cellml_namespace>` MAY contain an attribute with local name :code:`id.`
-   This attribute SHALL be treated as having attribute type ID, as defined in :xml_1_1:`section 3.3.1 <#sec-attribute-types>` of :xml_1_1:`XML 1.1 <>`.
+   This attribute SHALL be treated as having attribute type ID, as defined in :xml_1_1:`section 3.3.1 <#sec-attribute-types>` of :xml_1_1:`XML 1.1 <>` [ref_xml_1_1]_.
 
 .. marker_cellml_information_sets_end
 .. marker_data_formats_start

--- a/src/reference/sectionA_definitions.inc
+++ b/src/reference/sectionA_definitions.inc
@@ -7,9 +7,9 @@
 Terminology
 -----------
 
-The keywords "MUST", "MUST NOT", "SHALL", "SHALL NOT", and "MAY" in this document are to be interpreted as described in :rfc2119:`RFC 2119 <>` [:ref:`4<ref_rfc2119>`].
+The keywords "MUST", "MUST NOT", "SHALL", "SHALL NOT", and "MAY" in this document are to be interpreted as described in :rfc2119:`RFC 2119 <>` [:ref:`1<ref_rfc2119>`].
 
-The key phrase "information item", as well as any specific type of information item such as an "element information item", are to be interpreted as described in :xml_infoset:`XML Information Set <>` [:ref:`6<ref_xml_infoset>`].
+The key phrase "information item", as well as any specific type of information item such as an "element information item", are to be interpreted as described in :xml_infoset:`XML Information Set <>` [:ref:`2<ref_xml_infoset>`].
 
 .. _specA_cellml_infoset:
 
@@ -50,7 +50,7 @@ Any information item in the :ref:`CellML namespace<specA_cellml_namespace>`.
 .. _specA_basic_latin_alphabetical_character:
 
 **Basic Latin alphabetical character:**
-A :unicode13:`Unicode <>` [:ref:`5<ref_unicode>`] character in the range :unicode:`0041` to :unicode:`005A` or in the range :unicode:`0061` to :unicode:`007A`.
+A :unicode13:`Unicode <>` [:ref:`4<ref_unicode>`] character in the range :unicode:`0041` to :unicode:`005A` or in the range :unicode:`0061` to :unicode:`007A`.
 
 .. _specA_digit:
 
@@ -98,7 +98,7 @@ CellML information sets
 CellML and XML
 ~~~~~~~~~~~~~~
 
-#. Every :ref:`CellML infoset<specA_cellml_infoset>` SHALL be represented in an XML information set which conforms with the well-formedness requirements of :xml_1_1:`XML 1.1 <>` [:ref:`1<ref_xml_1_1>`].
+#. Every :ref:`CellML infoset<specA_cellml_infoset>` SHALL be represented in an XML information set which conforms with the well-formedness requirements of :xml_1_1:`XML 1.1 <>` [:ref:`5<ref_xml_1_1>`].
 
 #. In this document, the remaining provisions relating to CellML infosets SHALL be interpreted as additional constraints on the XML information set represented by a CellML infoset.
 
@@ -175,7 +175,7 @@ XML ID Attributes
 ~~~~~~~~~~~~~~~~~
 
 #. Any element information item in the :ref:`CellML namespace<specA_cellml_namespace>` MAY contain an attribute with local name :code:`id.`
-   This attribute SHALL be treated as having attribute type ID, as defined in :xml_1_1:`section 3.3.1 <#sec-attribute-types>` of :xml_1_1:`XML 1.1 <>` [:ref:`1<ref_xml_1_1>`].
+   This attribute SHALL be treated as having attribute type ID, as defined in :xml_1_1:`section 3.3.1 <#sec-attribute-types>` of :xml_1_1:`XML 1.1 <>` [:ref:`5<ref_xml_1_1>`].
 
 .. marker_cellml_information_sets_end
 .. marker_data_formats_start

--- a/src/reference/sectionB_elements.inc
+++ b/src/reference/sectionB_elements.inc
@@ -12,6 +12,8 @@ The ``model`` element
    The top-level element information item in a :ref:`CellML infoset<specA_cellml_infoset>` MUST be an element in the :ref:`CellML namespace<specA_cellml_namespace>` with a local name equal to :code:`model`.
    In this specification, the top-level element is referred to as the :code:`model` element.
 
+   testing [1]_ is here.
+
 
 .. container:: issue-model-name
 

--- a/src/reference/sectionB_elements.inc
+++ b/src/reference/sectionB_elements.inc
@@ -354,7 +354,7 @@ A :code:`math` element information item (referred to in this specification as a 
 
 .. container:: issue-math-mathml
 
-   1. A :code:`math` element MUST be the top-level element of a Content MathML tree, as described in :mathml2:`MathML 2.0 <>`.
+   1. A :code:`math` element MUST be the top-level element of a Content MathML tree, as described in :mathml2:`MathML 2.0 <>` [Ref_2]_.
 
 .. marker_math_1
 

--- a/src/reference/sectionB_elements.inc
+++ b/src/reference/sectionB_elements.inc
@@ -56,9 +56,9 @@ An :code:`import` element information item (referred to in this specification as
 
    1. Every :code:`import` element MUST contain an attribute in the namespace :code:`http://www.w3.org/1999/xlink`, with a local name equal to :code:`href`.
 
-      The value of this attribute SHALL be a valid locator :code:`href`, as defined in :href_locator:`Section 5.4 of the XLink specification <>` [:ref:`7<ref_xlink>`].
+      The value of this attribute SHALL be a valid locator :code:`href`, as defined in :href_locator:`Section 5.4 of the XLink specification <>` [:ref:`6<ref_xlink>`].
 
-      The :code:`href` attribute SHALL be treated according to the :xlink:`XLink specification` [:ref:`7<ref_xlink>`], by applying the rules for simple-type elements.
+      The :code:`href` attribute SHALL be treated according to the :xlink:`XLink specification` [:ref:`6<ref_xlink>`], by applying the rules for simple-type elements.
 
       When describing an :code:`import` element or one of its children, the phrase "imported CellML infoset" SHALL refer to the :ref:`CellML infoset<specA_cellml_infoset>` obtained by parsing the document referenced by the :code:`href` attribute.
 
@@ -354,7 +354,7 @@ A :code:`math` element information item (referred to in this specification as a 
 
 .. container:: issue-math-mathml
 
-   1. A :code:`math` element MUST be the top-level element of a Content MathML tree, as described in :mathml2:`MathML 2.0 <>` [:ref:`2<ref_mathml2>`].
+   1. A :code:`math` element MUST be the top-level element of a Content MathML tree, as described in :mathml2:`MathML 2.0 <>` [:ref:`7<ref_mathml2>`].
 
 .. marker_math_1
 

--- a/src/reference/sectionB_elements.inc
+++ b/src/reference/sectionB_elements.inc
@@ -56,9 +56,9 @@ An :code:`import` element information item (referred to in this specification as
 
    1. Every :code:`import` element MUST contain an attribute in the namespace :code:`http://www.w3.org/1999/xlink`, with a local name equal to :code:`href`.
 
-      The value of this attribute SHALL be a valid locator :code:`href`, as defined in :href_locator:`Section 5.4 of the XLink specification <>`.
+      The value of this attribute SHALL be a valid locator :code:`href`, as defined in :href_locator:`Section 5.4 of the XLink specification <>` [ref_xlink]_.
 
-      The :code:`href` attribute SHALL be treated according to the :xlink:`XLink specification`, by applying the rules for simple-type elements.
+      The :code:`href` attribute SHALL be treated according to the :xlink:`XLink specification` [ref_xlink]_, by applying the rules for simple-type elements.
 
       When describing an :code:`import` element or one of its children, the phrase "imported CellML infoset" SHALL refer to the :ref:`CellML infoset<specA_cellml_infoset>` obtained by parsing the document referenced by the :code:`href` attribute.
 

--- a/src/reference/sectionB_elements.inc
+++ b/src/reference/sectionB_elements.inc
@@ -12,8 +12,6 @@ The ``model`` element
    The top-level element information item in a :ref:`CellML infoset<specA_cellml_infoset>` MUST be an element in the :ref:`CellML namespace<specA_cellml_namespace>` with a local name equal to :code:`model`.
    In this specification, the top-level element is referred to as the :code:`model` element.
 
-   testing [1]_ is here.
-
 
 .. container:: issue-model-name
 

--- a/src/reference/sectionB_elements.inc
+++ b/src/reference/sectionB_elements.inc
@@ -56,9 +56,9 @@ An :code:`import` element information item (referred to in this specification as
 
    1. Every :code:`import` element MUST contain an attribute in the namespace :code:`http://www.w3.org/1999/xlink`, with a local name equal to :code:`href`.
 
-      The value of this attribute SHALL be a valid locator :code:`href`, as defined in :href_locator:`Section 5.4 of the XLink specification <>` [ref_xlink]_.
+      The value of this attribute SHALL be a valid locator :code:`href`, as defined in :href_locator:`Section 5.4 of the XLink specification <>` [Ref_7]_.
 
-      The :code:`href` attribute SHALL be treated according to the :xlink:`XLink specification` [ref_xlink]_, by applying the rules for simple-type elements.
+      The :code:`href` attribute SHALL be treated according to the :xlink:`XLink specification` [Ref_7]_, by applying the rules for simple-type elements.
 
       When describing an :code:`import` element or one of its children, the phrase "imported CellML infoset" SHALL refer to the :ref:`CellML infoset<specA_cellml_infoset>` obtained by parsing the document referenced by the :code:`href` attribute.
 

--- a/src/reference/sectionB_elements.inc
+++ b/src/reference/sectionB_elements.inc
@@ -56,9 +56,9 @@ An :code:`import` element information item (referred to in this specification as
 
    1. Every :code:`import` element MUST contain an attribute in the namespace :code:`http://www.w3.org/1999/xlink`, with a local name equal to :code:`href`.
 
-      The value of this attribute SHALL be a valid locator :code:`href`, as defined in :href_locator:`Section 5.4 of the XLink specification <>` [Ref_7]_.
+      The value of this attribute SHALL be a valid locator :code:`href`, as defined in :href_locator:`Section 5.4 of the XLink specification <>` [:ref:`7<ref_xlink>`].
 
-      The :code:`href` attribute SHALL be treated according to the :xlink:`XLink specification` [Ref_7]_, by applying the rules for simple-type elements.
+      The :code:`href` attribute SHALL be treated according to the :xlink:`XLink specification` [:ref:`7<ref_xlink>`], by applying the rules for simple-type elements.
 
       When describing an :code:`import` element or one of its children, the phrase "imported CellML infoset" SHALL refer to the :ref:`CellML infoset<specA_cellml_infoset>` obtained by parsing the document referenced by the :code:`href` attribute.
 
@@ -354,7 +354,7 @@ A :code:`math` element information item (referred to in this specification as a 
 
 .. container:: issue-math-mathml
 
-   1. A :code:`math` element MUST be the top-level element of a Content MathML tree, as described in :mathml2:`MathML 2.0 <>` [Ref_2]_.
+   1. A :code:`math` element MUST be the top-level element of a Content MathML tree, as described in :mathml2:`MathML 2.0 <>` [:ref:`2<ref_mathml2>`].
 
 .. marker_math_1
 

--- a/src/reference/sectionD_references.inc
+++ b/src/reference/sectionD_references.inc
@@ -1,15 +1,28 @@
 .. _sectionD:
 
-.. [Ref_1] Extensible Markup Language (XML) 1.1 :xml_1_1_display:`/`
+.. _ref_xml_1_1:
+1. Extensible Markup Language (XML) 1.1 :xml_1_1_display:`/`
 
-.. [Ref_2] Mathematical Markup Language (MathML) Version 2.0 :mathml2_display:`/`
+.. _ref_mathml2:
 
-.. [Ref_3] Namespaces in XML 1.1 :xml_namespace_1_1_display:`/`
+2. Mathematical Markup Language (MathML) Version 2.0 :mathml2_display:`/`
 
-.. [Ref_4] RFC 2119: Key words for use in RFCs to Indicate Requirement Levels :rfc2119_display:`rfc2119.txt`
+.. _ref_xml_namespace_1_1:
 
-.. [Ref_5] Unicode 13.0.0 :unicode13_display:`/`
+3. Namespaces in XML 1.1 :xml_namespace_1_1_display:`/`
 
-.. [Ref_6] XML Information Set :xml_infoset_display:`/`
+.. _ref_rfc2119:
 
-.. [Ref_7] XML Linking Language (XLink) Version 1.1 :xlink_display:`/`
+4. RFC 2119: Key words for use in RFCs to Indicate Requirement Levels :rfc2119_display:`rfc2119.txt`
+
+.. _ref_unicode:
+
+5. Unicode 13.0.0 :unicode13_display:`/`
+
+.. _ref_xml_infoset:
+
+6. XML Information Set :xml_infoset_display:`/`
+
+.. _ref_xlink:
+
+7. XML Linking Language (XLink) Version 1.1 :xlink_display:`/`

--- a/src/reference/sectionD_references.inc
+++ b/src/reference/sectionD_references.inc
@@ -1,15 +1,15 @@
 .. _sectionD:
 
-Extensible Markup Language (XML) 1.1 :xml_1_1_display:`/`
+.. [ref_xml_1_1] Extensible Markup Language (XML) 1.1 :xml_1_1_display:`/`
 
-Mathematical Markup Language (MathML) Version 2.0 :mathml2_display:`/`
+.. [ref_mathml2] Mathematical Markup Language (MathML) Version 2.0 :mathml2_display:`/`
 
-Namespaces in XML 1.1 :xml_namespace_1_1_display:`/`
+.. [ref_xml_namespace_1_1] Namespaces in XML 1.1 :xml_namespace_1_1_display:`/`
 
-RFC 2119: Key words for use in RFCs to Indicate Requirement Levels :rfc2119_display:`rfc2119.txt`
+.. [ref_rfc2119] RFC 2119: Key words for use in RFCs to Indicate Requirement Levels :rfc2119_display:`rfc2119.txt`
 
-Unicode 13.0.0 :unicode13_display:`/`
+.. [ref_unicode] Unicode 13.0.0 :unicode13_display:`/`
 
-XML Information Set :xml_infoset_display:`/`
+.. [ref_xml_infoset] XML Information Set :xml_infoset_display:`/`
 
-XML Linking Language (XLink) Version 1.1 :xlink_display:`/`
+.. [ref_xlink] XML Linking Language (XLink) Version 1.1 :xlink_display:`/`

--- a/src/reference/sectionD_references.inc
+++ b/src/reference/sectionD_references.inc
@@ -1,29 +1,29 @@
 .. _sectionD:
 
-.. _ref_xml_1_1:
+.. _ref_rfc2119:
 
-1. Extensible Markup Language (XML) 1.1 :xml_1_1_display:`/`
+1. RFC 2119: Key words for use in RFCs to Indicate Requirement Levels :rfc2119_display:`rfc2119.txt`
 
-.. _ref_mathml2:
+.. _ref_xml_infoset:
 
-2. Mathematical Markup Language (MathML) Version 2.0 :mathml2_display:`/`
+2. XML Information Set :xml_infoset_display:`/`
 
 .. _ref_xml_namespace_1_1:
 
 3. Namespaces in XML 1.1 :xml_namespace_1_1_display:`/`
 
-.. _ref_rfc2119:
-
-4. RFC 2119: Key words for use in RFCs to Indicate Requirement Levels :rfc2119_display:`rfc2119.txt`
-
 .. _ref_unicode:
 
-5. Unicode 13.0.0 :unicode13_display:`/`
+4. Unicode 13.0.0 :unicode13_display:`/`
 
-.. _ref_xml_infoset:
+.. _ref_xml_1_1:
 
-6. XML Information Set :xml_infoset_display:`/`
+5. Extensible Markup Language (XML) 1.1 :xml_1_1_display:`/`
 
 .. _ref_xlink:
 
-7. XML Linking Language (XLink) Version 1.1 :xlink_display:`/`
+6. XML Linking Language (XLink) Version 1.1 :xlink_display:`/`
+
+.. _ref_mathml2:
+
+7. Mathematical Markup Language (MathML) Version 2.0 :mathml2_display:`/`

--- a/src/reference/sectionD_references.inc
+++ b/src/reference/sectionD_references.inc
@@ -13,3 +13,5 @@
 .. [ref_xml_infoset] XML Information Set :xml_infoset_display:`/`
 
 .. [ref_xlink] XML Linking Language (XLink) Version 1.1 :xlink_display:`/`
+
+.. [1] testing

--- a/src/reference/sectionD_references.inc
+++ b/src/reference/sectionD_references.inc
@@ -1,6 +1,7 @@
 .. _sectionD:
 
 .. _ref_xml_1_1:
+
 1. Extensible Markup Language (XML) 1.1 :xml_1_1_display:`/`
 
 .. _ref_mathml2:

--- a/src/reference/sectionD_references.inc
+++ b/src/reference/sectionD_references.inc
@@ -1,15 +1,15 @@
 .. _sectionD:
 
-.. [ref_xml_1_1] Extensible Markup Language (XML) 1.1 :xml_1_1_display:`/`
+.. [Ref_1] Extensible Markup Language (XML) 1.1 :xml_1_1_display:`/`
 
-.. [ref_mathml2] Mathematical Markup Language (MathML) Version 2.0 :mathml2_display:`/`
+.. [Ref_2] Mathematical Markup Language (MathML) Version 2.0 :mathml2_display:`/`
 
-.. [ref_xml_namespace_1_1] Namespaces in XML 1.1 :xml_namespace_1_1_display:`/`
+.. [Ref_3] Namespaces in XML 1.1 :xml_namespace_1_1_display:`/`
 
-.. [ref_rfc2119] RFC 2119: Key words for use in RFCs to Indicate Requirement Levels :rfc2119_display:`rfc2119.txt`
+.. [Ref_4] RFC 2119: Key words for use in RFCs to Indicate Requirement Levels :rfc2119_display:`rfc2119.txt`
 
-.. [ref_unicode] Unicode 13.0.0 :unicode13_display:`/`
+.. [Ref_5] Unicode 13.0.0 :unicode13_display:`/`
 
-.. [ref_xml_infoset] XML Information Set :xml_infoset_display:`/`
+.. [Ref_6] XML Information Set :xml_infoset_display:`/`
 
-.. [ref_xlink] XML Linking Language (XLink) Version 1.1 :xlink_display:`/`
+.. [Ref_7] XML Linking Language (XLink) Version 1.1 :xlink_display:`/`

--- a/src/reference/sectionD_references.inc
+++ b/src/reference/sectionD_references.inc
@@ -13,5 +13,3 @@
 .. [ref_xml_infoset] XML Information Set :xml_infoset_display:`/`
 
 .. [ref_xlink] XML Linking Language (XLink) Version 1.1 :xlink_display:`/`
-
-.. [1] testing


### PR DESCRIPTION
Addresses #280 and #288 

Numbered references throughout the text so that people who are reading on paper can follow them.  

Global numbering is not supported (ie, can't use [1] etc) as that's reserved for local footnotes.  I've used [Ref_1] ... but open to other ideas ...

Rendered version is here: https://cellml-specification-dev.readthedocs.io/en/i280_numbering_references/reference/formal_only/specA2.html#cellml-and-xml