### PR TITLE
I314 numref hoverxref

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 sphinx>2,<3
-sphinx-hoverxref
+git+git://github.com/readthedocs/sphinx-hoverxref.git
+# sphinx-hoverxref
 sphinx_rtd_theme

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 sphinx>2,<3
-git+git://github.com/readthedocs/sphinx-hoverxref@releases/tag/0.4b1#egg=sphinx-hoverxref
+git+git://github.com/readthedocs/sphinx-hoverxref@releases/tag/0.4b1
 sphinx_rtd_theme

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 sphinx>2,<3
-git+git://github.com/readthedocs/sphinx-hoverxref@releases/tag/0.4b1
+git+git://github.com/readthedocs/sphinx-hoverxref@releases/tag/v0.4b1#egg=sphinx-hoverxref
 sphinx_rtd_theme

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 sphinx>2,<3
-git+git://github.com/readthedocs/sphinx-hoverxref.git@master
+# git+git://github.com/readthedocs/sphinx-hoverxref.git@master
+sphinx-hoverxref
 sphinx_rtd_theme

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 sphinx>2,<3
-git+git://github.com/readthedocs/sphinx-hoverxref@releases/tag/v0.4b1#egg=sphinx-hoverxref
+git+git://github.com/readthedocs/sphinx-hoverxref@v0.4b1#egg=sphinx-hoverxref
 sphinx_rtd_theme

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 sphinx>2,<3
-# git+git://github.com/readthedocs/sphinx-hoverxref.git@master
 sphinx-hoverxref
 sphinx_rtd_theme

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 sphinx>2,<3
-git+git://github.com/readthedocs/sphinx-hoverxref@0.4b1#egg=sphinx-hoverxref
+sphinx-hoverxref
 sphinx_rtd_theme

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 sphinx>2,<3
-git+git://github.com/readthedocs/sphinx-hoverxref@v0.4b1#egg=sphinx-hoverxref
+git+git://github.com/readthedocs/sphinx-hoverxref@0.4b1#egg=sphinx-hoverxref
 sphinx_rtd_theme

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 sphinx>2,<3
-git+git://github.com/readthedocs/sphinx-hoverxref.git@humitos/support-numref
+sphinx-hoverxref
 sphinx_rtd_theme

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 sphinx>2,<3
-git+git://github.com/readthedocs/sphinx-hoverxref.git
-# sphinx-hoverxref
+git+git://github.com/readthedocs/sphinx-hoverxref.git@master
 sphinx_rtd_theme

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 sphinx>2,<3
-# git+git://github.com/readthedocs/sphinx-hoverxref.git@master
-sphinx-hoverxref
+git+git://github.com/readthedocs/sphinx-hoverxref.git@master
 sphinx_rtd_theme

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 sphinx>2,<3
-git+git://github.com/readthedocs/sphinx-hoverxref/releases/tag/0.4b1#egg=sphinx-hoverxref
+git+git://github.com/readthedocs/sphinx-hoverxref@releases/tag/0.4b1#egg=sphinx-hoverxref
 sphinx_rtd_theme

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 sphinx>2,<3
-sphinx-hoverxref
+git+git://github.com/readthedocs/sphinx-hoverxref.git@humitos/support-numref
 sphinx_rtd_theme

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 sphinx>2,<3
+# git+git://github.com/readthedocs/sphinx-hoverxref.git@master
 sphinx-hoverxref
 sphinx_rtd_theme

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 sphinx>2,<3
-git+git://github.com/readthedocs/sphinx-hoverxref.git@master
+git+git://github.com/readthedocs/sphinx-hoverxref/releases/tag/0.4b1#egg=sphinx-hoverxref
 sphinx_rtd_theme

--- a/src/conf.py
+++ b/src/conf.py
@@ -263,7 +263,7 @@ html_context = {
 # Automagically convert all :ref: blocks to show a tooltip using the hoverxref
 # extension.
 hoverxref_auto_ref = True
-hoverxref_roles = ['term', 'code']
+hoverxref_roles = ['numref', 'term', 'code']
 
 # Add any paths that contain custom themes here, relative to this directory.
 # html_theme_path = ['@SPHINX_THEME_DIR@']

--- a/src/conf.py
+++ b/src/conf.py
@@ -262,7 +262,7 @@ html_context = {
 
 # Automagically convert all :ref: blocks to show a tooltip using the hoverxref
 # extension.
-hoverxref_auto_ref = False
+hoverxref_auto_ref = True
 hoverxref_roles = ['ref', 'numref']
 hoverxref_role_types = {
     'ref': 'tooltip',       

--- a/src/conf.py
+++ b/src/conf.py
@@ -262,10 +262,9 @@ html_context = {
 
 # Automagically convert all :ref: blocks to show a tooltip using the hoverxref
 # extension.
-hoverxref_auto_ref = True
-hoverxref_roles = ['numref']
+hoverxref_auto_ref = False
+hoverxref_roles = ['ref', 'numref']
 hoverxref_role_types = {
-    'hoverxref': 'tooltip',
     'ref': 'tooltip',       
     'numref': 'tooltip',    
 }

--- a/src/conf.py
+++ b/src/conf.py
@@ -263,7 +263,12 @@ html_context = {
 # Automagically convert all :ref: blocks to show a tooltip using the hoverxref
 # extension.
 hoverxref_auto_ref = True
-hoverxref_roles = ['numref', 'term', 'code']
+hoverxref_roles = ['numref']
+hoverxref_role_types = {
+    'hoverxref': 'tooltip',
+    'ref': 'tooltip',       
+    'numref': 'tooltip',    
+}
 
 # Add any paths that contain custom themes here, relative to this directory.
 # html_theme_path = ['@SPHINX_THEME_DIR@']

--- a/src/conf.py
+++ b/src/conf.py
@@ -263,7 +263,7 @@ html_context = {
 # Automagically convert all :ref: blocks to show a tooltip using the hoverxref
 # extension.
 hoverxref_auto_ref = True
-hoverxref_roles = ['ref', 'numref']
+# hoverxref_roles = ['ref', 'numref']
 hoverxref_role_types = {
     'ref': 'tooltip',       
     'numref': 'tooltip',    

--- a/src/conf.py
+++ b/src/conf.py
@@ -263,7 +263,7 @@ html_context = {
 # Automagically convert all :ref: blocks to show a tooltip using the hoverxref
 # extension.
 hoverxref_auto_ref = True
-# hoverxref_roles = ['ref', 'numref']
+hoverxref_roles = ['ref', 'numref']
 hoverxref_role_types = {
     'ref': 'tooltip',       
     'numref': 'tooltip',    


### PR DESCRIPTION
Closes #314 

... but ... this currently is proof of concept as it requires a branch from the hoverxref repo.  It can be merged now if we're desperate, or we can wait for it to be included in their update.

See change in the requirements file that would need to be reverted.  

Rendered docs are here: https://cellml-specification-dev.readthedocs.io/en/i314_numref_hoverxref/reference/formal_and_informative/specB09.html