### PR TITLE
Changed ref into numref where appropriate in informative blocks

### DIFF
--- a/src/reference/informative/informA2_5.rst
+++ b/src/reference/informative/informA2_5.rst
@@ -19,7 +19,7 @@
     Finally, there are aspects of the *written* XML which do not contribute to the *conceptual* model as represented by the CellML; simple examples are things like whitespace between elements, comments, quotation and angle bracket markers.
     These are all parts of the written language which guide interpretation into the conceptual model.
     The :code:`id` attribute is likewise an XML attribute which falls into the same category: it may be read when a document is parsed, but as it doesn't form a part of any CellML element, it doesn't exist in the constructed conceptual representation.
-    Having said this, the syntax of CellML is a subset of XML (as specified in :ref:`CellML information sets<specA_cellml_information_sets>`), so the rules of XML :code:`id` attributes must be followed, where present.
+    Having said this, the syntax of CellML is a subset of XML (as specified in :numref:`{number} {name}<specA_cellml_information_sets>`), so the rules of XML :code:`id` attributes must be followed, where present.
 
     Consider the example below.
 

--- a/src/reference/informative/informB12_math3.rst
+++ b/src/reference/informative/informB12_math3.rst
@@ -38,7 +38,7 @@
 
     This situation is not valid, as the :code:`math` block in component :code:`mass_into_energy` doesn't have access to the variable :code:`m` in the component :code:`calculate_mass`.
     To get around this, you would need to create a new local variable within the :code:`mass_into_energy` component, and use a :code:`connection` element to link it to the mass variable :code:`m` in the other component.
-    The valid form of the model is shown below. You can read more about :code:`connections` in :ref:`The connection element<specB_connection>`, and the :code:`interface_type` attribute in :ref:`The variable element<specB_variable>`.
+    The valid form of the model is shown below. You can read more about :code:`connections` in :numref:`{number} {name}<specB_connection>`, and the :code:`interface_type` attribute in :numref:`{number} {name}<specB_variable>`.
 
     .. code-block:: xml
 

--- a/src/reference/informative/informB14_component_ref1.rst
+++ b/src/reference/informative/informB14_component_ref1.rst
@@ -9,4 +9,4 @@
 
   .. container:: infospec
 
-    Please see the notes about the :code:`component_ref` usage under the "See more" link on the :ref:`encapsulation element<encapsulation>` page.
+    Please see the notes about the :code:`component_ref` usage under the "See more" link in :numref:`{number} {name}<encapsulation>`.

--- a/src/reference/informative/informB15_connection2.rst
+++ b/src/reference/informative/informB15_connection2.rst
@@ -11,7 +11,7 @@
     Creating :code:`connection` items allows :code:`variable` values to be passed between eligible :code:`components`.
     There are both syntactic (i.e.: format) and semantic (i.e.: meaning) rules about how these must be specified, including what "eligible" means.
     Syntax will be discussed below and in the other "See more" blocks on this page.
-    For more on the semantic rules, please see :ref:`Interpretation of map_variables<specC_interpretation_of_map_variables>`.
+    For more on the semantic rules, please see :numref:`{number} {name}<specC_interpretation_of_map_variables>`.
 
     Both points above are really saying the same thing.
     The way in which you specify the :code:`component_1` and :code:`component_2` items must follow the general CellML 2.0 format for a valid identifier, and must point to a :code:`component` which exists under that name (note that this could be either an intantiated :code:`component`, or an :code:`import component` item).

--- a/src/reference/informative/informB1_model3.rst
+++ b/src/reference/informative/informB1_model3.rst
@@ -12,4 +12,4 @@
     This in turn affects which variables have access to which other variables, and allows the modular behaviour to happen at any level.
     For this reason, there can be only one :code:`encapsulation` item in any model.
 
-    For more information about encapsulation, please refer to :ref:`The encapsulation element information item<specB_encapsulation>`.
+    For more information about encapsulation, please refer to :numref:`{number} {name}<specB_encapsulation>`.

--- a/src/reference/informative/informB3_import_units1.rst
+++ b/src/reference/informative/informB3_import_units1.rst
@@ -14,7 +14,7 @@
         - A destination item in the importing model (this is the :code:`units` item called :code:`smallPotOfPaint` in the example below).
 
         - A file to import from, specified using the :code:`xlink:href` attribute of the parent :code:`import` block.
-          This is discussed in more detail in :ref:`The import element information item<specB_import>`.
+          This is discussed in more detail in :numref:`{number} {name}<specB_import>`.
           In the example below this is the :code:`paint_pot_sizes.cellml` file.
 
         - The specific item name to retrieve from the imported file.
@@ -32,7 +32,7 @@
 
       Imported items have the same restrictions as concrete items regarding the uniqueness of their names.
       In the example below, the name :code:`potOfPaint` is used for the locally defined units in line 2, but the same name is used as the name for the imported units in line 6.
-      This is not permitted as it violates :ref:`the uniqueness requirement for unit names<issue_units_name>`\.
+      This is not permitted as it violates :numref:`{number} {name}<issue_units_name>`.
 
       .. code-block:: xml
 

--- a/src/reference/informative/informB3_import_units1.rst
+++ b/src/reference/informative/informB3_import_units1.rst
@@ -32,7 +32,7 @@
 
       Imported items have the same restrictions as concrete items regarding the uniqueness of their names.
       In the example below, the name :code:`potOfPaint` is used for the locally defined units in line 2, but the same name is used as the name for the imported units in line 6.
-      This is not permitted as it violates :numref:`{number} {name}<issue_units_name>`.
+      This is not permitted as it violates the :ref:`unique name<issue_units_name>` requirement.
 
       .. code-block:: xml
 

--- a/src/reference/informative/informB4_import_component1.rst
+++ b/src/reference/informative/informB4_import_component1.rst
@@ -14,7 +14,7 @@
       - A destination in the importing model (this is the :code:`component` item called :code:`pi_calculator` in the example below),
 
       - A file to import from, specified using the :code:`xlink:href` attribute of the parent :code:`import` block.
-        This is discussed in more detail in :ref:`The import element information item<specB_import>`.
+        This is discussed in more detail in :numref:`{number} {name}<specB_import>`.
         In the example below this is the :code:`pi_approximators.cellml` file.
 
       - The specific item name to retrieve from the imported file.
@@ -37,7 +37,7 @@
        Imported items have the same restrictions as locally defined items regarding the uniqueness of their names and their format.
        In the example below, the name :code:`pi_calculator` is used for the locally defined component in line 2, but the same name is used as the name for the imported component in line 6.
        This is not permitted as it violates the uniqueness requirement for names specified above.
-       The second imported component uses an invalid name attribute (see :ref:`Data representation formats in CellML<specA_data_representation_formats>`) so is not permitted either.
+       The second imported component uses an invalid name attribute (see :numref:`{number} {name}<specA_data_representation_formats>`) so is not permitted either.
 
     .. code-block:: xml
 
@@ -59,7 +59,7 @@
       </model>
 
     3. **The component_ref attribute**.
-       This must be a :ref:`valid CellML identifier<specA_cellml_identifier>` (see :ref:`Data representation formats in CellML<specA_data_representation_formats>`).
+       This must be a :ref:`valid CellML identifier<specA_cellml_identifier>` (see :numref:`{number} {name}<specA_data_representation_formats>`).
        It also has to actually exist as a :code:`component` in the given :code:`href` location!
        Neither of the imports below are permitted:
 

--- a/src/reference/informative/informB5_units1.rst
+++ b/src/reference/informative/informB5_units1.rst
@@ -8,7 +8,7 @@
 
   .. container:: infospec
 
-    The best way to understand how :code:`units` work is to read the informative sections within the :ref:`Unit element section<unit>` in the next section, which defines their child :code:`unit` items.
+    The best way to understand how :code:`units` work is to read the informative sections within the :numref:`{number} {name}<unit>` in the next section, which defines their child :code:`unit` items.
 
     The following examples show examples of what is not permitted when defining :code:`units` items.
 

--- a/src/reference/informative/informB6_unit2.rst
+++ b/src/reference/informative/informB6_unit2.rst
@@ -58,4 +58,4 @@
         <unit units="second" exponent="-1">
       </units>
 
-    For more information on :code:`units` items please refer to :ref:`the previous section<units>`.
+    For more information on :code:`units` items please refer to :numref:`{number} {name}<units>`.

--- a/src/reference/informative/informB7_component1.rst
+++ b/src/reference/informative/informB7_component1.rst
@@ -14,5 +14,5 @@
 
     Components are the largest building blocks of the model, and have three important parts to them.
     The first is their naming and contents, similar to all the other CellML items, and described below.
-    The second relates to their structure in relation to other :code:`component` items: this structure is called their *encapsulation* and is described in :ref:`The encapsulation item<encapsulation>`.
-    The third relates to the :code:`import component` item, as described in :ref:`The import_component item<import_component>`.
+    The second relates to their structure in relation to other :code:`component` items: this structure is called their *encapsulation* and is described in :numref:`{number} {name}<encapsulation>`.
+    The third relates to the :code:`import component` item, as described in :numref:`{number} {name}<import_component>`.

--- a/src/reference/informative/informB7_component2.rst
+++ b/src/reference/informative/informB7_component2.rst
@@ -8,7 +8,7 @@
 
   .. container:: infospec
 
-    A :code:`component` item, as with every other part of CellML, must use a name unique to its scope, and obey the format definitions outlined in :ref:`Data representation formats<specA_data_representation_formats>`.
+    A :code:`component` item, as with every other part of CellML, must use a name unique to its scope, and obey the format definitions outlined in :numref:`{number} {name}<specA_data_representation_formats>`.
     For example:
 
     .. code-block:: xml

--- a/src/reference/informative/informB7_component3.rst
+++ b/src/reference/informative/informB7_component3.rst
@@ -13,7 +13,7 @@
       The mathematics of a component
 
     Perhaps the most important part of a :code:`component` item is the mathematics it contains.
-    This is stored inside a collection of :code:`<math>` blocks as described in :ref:`The math element<specB_math>`.
+    This is stored inside a collection of :code:`<math>` blocks as described in :numref:`{number} {name}<specB_math>`.
     The :code:`math` then defines the operation of the local :code:`variable` items and how they relate to each other mathematically.
 
     For example, a component to calculate Einstein's :math:`E=mc^2` could be represented by:
@@ -36,7 +36,7 @@
         ...
       </component>
 
-    Please refer to the :ref:`math element<math>` section for information on the :code:`math` items and MathML format.
+    Please refer to :numref:`{number} {name}<math>` for information on the :code:`math` items and MathML format.
 
     .. container:: heading3
 
@@ -54,10 +54,10 @@
         <variable name="c" units="metres_per_second" />
       </component>
 
-    Please refer to the :ref:`variable element<variable>` section for information on :code:`variable` items.
+    Please refer to :numref:`{number} {name}<variable>` for information on :code:`variable` items.
 
     .. container:: heading3
 
       The reset items of a component
 
-    Please refer to the :ref:`reset element<reset>` section for more information on :code:`reset` items.
+    Please refer to :numref:`{number} {name}<reset>` for more information on :code:`reset` items.

--- a/src/reference/informative/informB8_variable1.rst
+++ b/src/reference/informative/informB8_variable1.rst
@@ -10,7 +10,7 @@
 
     In addition to the standard :code:`name` attribute, each :code:`variable` must also define a :code:`units` attribute too.
 
-    Reusing Einstein's example from the :ref:`component item<specB_component>` section we can give the three variables their fuller definitions:
+    Reusing Einstein's example from :numref:`{number} {name}<specB_component>` section we can give the three variables their fuller definitions:
 
     .. code-block:: xml
 
@@ -24,8 +24,8 @@
       </component>
 
     Extra attributes that can be used as needed include the :code:`initial_value`, which will either set a constant value for a variable, or set its initial conditions if it's being solved for.
-    More information about initialisation can be found in the :ref:`Interpretation of initial values<specC_interpretation_of_initial_values>` section.
+    More information about initialisation can be found in :numref:`{number} {name}<specC_interpretation_of_initial_values>`.
 
     Finally, where one :code:`variable` (A) has been mapped to another (B) in a different component (BB), both A and B must specify :code:`interface` attributes.
     These prescribe the relative positions in the encapsulation that the components AA and BB must have in order for their respective variables A and B to access one another.
-    This is outlined in more detail in the :ref:`encapsulation element<specB_encapsulation>` section.
+    This is outlined in more detail in :numref:`{number} {name}<specB_encapsulation>`.

--- a/src/reference/informative/informC01_imports.rst
+++ b/src/reference/informative/informC01_imports.rst
@@ -8,4 +8,4 @@
 
   .. container:: infospec
 
-    Please see the informative sections on :ref:`Units reference<specC_units_reference>` and :ref:`Component reference<specC_component_reference>` pages for examples specific to importing :code:`units` and :code:`component` elements.
+    Please see the informative sections on :numref:`{number} {name}<specC_units_reference>` and :numref:`{number} {name}<specC_component_reference>` pages for examples specific to importing :code:`units` and :code:`component` elements.

--- a/src/reference/informative/informC07_effect_of_units_on_variables.rst
+++ b/src/reference/informative/informC07_effect_of_units_on_variables.rst
@@ -24,8 +24,7 @@
       There are examples and further details available in :numref:`{number} {name}<specC_interpretation_of_map_variables>`.
 
     - When variables are created to operate *within* a component (its local mathematics) their units are not checked; the modeller *does* have knowledge of the inner workings, and can control and interpret them as needed.
-      There are examples and further details available in :ref:`3.8.3 inside Interpretation of math elements<specC_units_and_maths>`.
+      There are examples and further details available in :hardcodedref:`3.8.3` in :numref:`{number} {name}<specC_units_and_maths>`.
 
     Thus, CellML deems it important for the component border crossings to have as much information as possible (that is: the units and variable pairs), yet permits modellers the flexibility to make their own decisions about units within components.
 
-.. hardcodedref above, 3.8.3

--- a/src/reference/informative/informC08_interpretation_of_mathematics2.rst
+++ b/src/reference/informative/informC08_interpretation_of_mathematics2.rst
@@ -14,7 +14,7 @@
 
     The mathematics of a mathematical model is a collection of statements which are held to be true at all times.
     These are distinct from initial conditions of a model (specified using the :code:`initial_value` attribute on :code:`variable` elements) which are only true initially.
-    You can read more about initialisation on the :ref:`Interpretation of initial_values<specC_interpretation_of_initial_values>` page and in the section below this one.
+    You can read more about initialisation in :numref:`{number} {name}<specC_interpretation_of_initial_values>` page and in the section below this one.
 
     The collection of mathematical statements in a CellML model is the set of children of all :code:`math` elements inside its "pertinent components" (as explained in the previous block).
     The example from the previous point is extended below in pseudocode, with the full CellML code beneath the link below.

--- a/src/reference/informative/informC08_interpretation_of_mathematics3.rst
+++ b/src/reference/informative/informC08_interpretation_of_mathematics3.rst
@@ -124,8 +124,8 @@
             </connection>
           </model>
 
-    2. Any custom of built-in units with *differing* unit reduction tuples between connected variables: invalid, as it contradicts point :hardcodedref:`3.10.6` in the :ref:`Interpretation of map_variables<specC_interpretation_of_map_variables>` section.  
-       Please see the third informative block on the :ref:`Interpretation of units<specC_interpretation_of_units>` section for more discussion and examples of unit reductions.
+    2. Any custom of built-in units with *differing* unit reduction tuples between connected variables: invalid, as it contradicts point :hardcodedref:`3.10.6` in :numref:`{number} {name}<specC_interpretation_of_map_variables>`.  
+       Please see the third informative block in :numref:`{number} {name}<specC_interpretation_of_units>` section for more discussion and examples of unit reductions.
 
       .. code::
 

--- a/src/reference/informative/informC09_interpretation_of_encapsulation3.rst
+++ b/src/reference/informative/informC09_interpretation_of_encapsulation3.rst
@@ -61,4 +61,4 @@
       <connection component_1="GrannyMoses" component_2="LukeClampett" />
     
     The second rule above addresses the restrictions around which :code:`variable` elements are able to access one another.
-    This is a little more complicated, and explained in more detail in the informative block on the :ref:`interpretation of map_variables<specC_interpretation_of_map_variables>` section.
+    This is a little more complicated, and explained in more detail in the informative block in :numref:`{number} {name}<specC_interpretation_of_map_variables>`.

--- a/src/reference/informative/informC10_interpretation_of_map_variables5.rst
+++ b/src/reference/informative/informC10_interpretation_of_map_variables5.rst
@@ -13,7 +13,7 @@
       Understanding interfaces
 
     There are two hurdles to get past before variables can be mapped to one another.
-    The first is the relative position within the encapsulation hierarchy of the :code:`variable` elements' parent :code:`component` elements (as discussed in :ref:`Interpretation of encapsulation<specC_interpretation_of_encapsulation>`, and the second is the value of the :code:`interface_type` attribute given to each :code:`variable` itself.
+    The first is the relative position within the encapsulation hierarchy of the :code:`variable` elements' parent :code:`component` elements (as discussed in :numref:`{number} {name}<specC_interpretation_of_encapsulation>`, and the second is the value of the :code:`interface_type` attribute given to each :code:`variable` itself.
     This means that even if two components are sufficiently close relatives that they *can* be connected, the modeller still has control at the individual variable level as to which of those relatives can have access.
 
     The :code:`interface_type` attribute value choices are: 


### PR DESCRIPTION
Addresses #328 

Where appropriate, use numref not ref throughout the informative spec.  

See eg: https://cellml-specification-dev.readthedocs.io/en/i328_numref_in_informative_blocks/reference/formal_and_informative/specB07.html reference in first See more block.