### PR TITLE
Revert manual heading numbering.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-sphinx>2,<3
+sphinx>4
 sphinx-hoverxref
 sphinx_rtd_theme

--- a/src/conf.py
+++ b/src/conf.py
@@ -64,6 +64,7 @@ def define_excluded_patterns():
     if build_type == 'Normative':
         exclude_patterns = ['master_index.rst',
                             'reference/index_section*',
+                            'reference/examples/*/*.rst',
                             'reference/formal_and_informative/*.rst',
                             'reference/informative/*.rst',
                             'reference/libcellml/*.rst', ]

--- a/src/conf.py
+++ b/src/conf.py
@@ -117,65 +117,65 @@ autosectionlabel_prefix_document = True
 #   OR, where you want to print out the URL to the rendered version:
 #   'shortcut': ('http://linkhere%s', None) then use :shortcut:`/` in the text to display full URL, including the trailing slash.
 extlinks = {
-    'buildbot': ('https://buildbot.net%s', ''),
-    'calvin_and_hobbes': ('https://www.gocomics.com/calvinandhobbes/%s', ''),
-    'cellml1to2': ('https://github.com/hsorby/cellml1to2%s', ''),
+    'buildbot': ('https://buildbot.net%s', None),
+    'calvin_and_hobbes': ('https://www.gocomics.com/calvinandhobbes/%s', None),
+    'cellml1to2': ('https://github.com/hsorby/cellml1to2%s', None),
     'cellml2namespace': ('http://www.cellml.org/cellml/2.0%s', None),
     'cellml2spec_display': ('https://cellml.org/specifications/cellml_2.0%s', None),
-    'cellsolver': ('https://github.com/hsorby/cellsolver%s', ''),
-    'cmake': ('https://cmake.org/%s', ''),
-    'cvode': ('https://computing.llnl.gov/projects/sundials/cvode%s', ''),
-    'doxygen': ('http://www.doxygen.nl/%s', ''),
-    'euler_method': ('https://en.wikipedia.org/wiki/Euler_method%s', ''),
-    'git': ('https://git-scm.com/%s', ''),
-    'github': ('https://github.com/%s', ''),
-    'google_styleguide': ('https://google.github.io/styleguide/cppguide.html/%s', ''),
-    'libcellml': ('https://libcellml.org/%s', ''),
-    'libcellml_repo': ('https://github.com/cellml/libcellml.git%s', ''),
-    'libxml2': ('http://www.xmlsoft.org/%s', ''),
+    'cellsolver': ('https://github.com/hsorby/cellsolver%s', None),
+    'cmake': ('https://cmake.org/%s', None),
+    'cvode': ('https://computing.llnl.gov/projects/sundials/cvode%s', None),
+    'doxygen': ('http://www.doxygen.nl/%s', None),
+    'euler_method': ('https://en.wikipedia.org/wiki/Euler_method%s', None),
+    'git': ('https://git-scm.com/%s', None),
+    'github': ('https://github.com/%s', None),
+    'google_styleguide': ('https://google.github.io/styleguide/cppguide.html/%s', None),
+    'libcellml': ('https://libcellml.org/%s', None),
+    'libcellml_repo': ('https://github.com/cellml/libcellml.git%s', None),
+    'libxml2': ('http://www.xmlsoft.org/%s', None),
 
     # These should be identical: one for links, one for full URL display
-    'mathml2':         ('https://www.w3.org/TR/MathML2%s', ''),
+    'mathml2':         ('https://www.w3.org/TR/MathML2%s', None),
     'mathml2_display': ('https://www.w3.org/TR/MathML2%s', None),
 
-    'mathml2help': ('https://www.w3.org/TR/MathML2/chapter4.html%s', ''),
+    'mathml2help': ('https://www.w3.org/TR/MathML2/chapter4.html%s', None),
 
     # This will get MathML added to the end so it becomes http://www.w3.org/1998/Math/MathML
     # in the final display, to avoid trailing slashes.
     'mathml2namespace': ('http://www.w3.org/1998/Math/%s', None),
 
-    'namespace_help': ('https://www.w3schools.com/xml/xml_namespaces.asp%s', ''),
-    'opencor': ('https://opencor.ws/%s', ''),
-    'pmr': ('https://models.physiomeproject.org/%s', ''),
-    'python': ('https://www.python.org/%s', ''),
+    'namespace_help': ('https://www.w3schools.com/xml/xml_namespaces.asp%s', None),
+    'opencor': ('https://opencor.ws/%s', None),
+    'pmr': ('https://models.physiomeproject.org/%s', None),
+    'python': ('https://www.python.org/%s', None),
 
     # These should be identical: one for links, one for full URL display
-    'rfc2119':         ('https://www.ietf.org/rfc/rfc2119.txt%s', ''),
+    'rfc2119':         ('https://www.ietf.org/rfc/rfc2119.txt%s', None),
     'rfc2119_display': ('https://www.ietf.org/rfc/%s', None),
 
-    'sphinx': ('http://sphinx-doc.org/%s', ''),
-    'swig': ('http://www.swig.org/%s', ''),
-    'unicode': ('http://www.fileformat.info/info/unicode/char/%s/index.htm', 'U+'),
+    'sphinx': ('http://sphinx-doc.org/%s', None),
+    'swig': ('http://www.swig.org/%s', None),
+    'unicode': ('http://www.fileformat.info/info/unicode/char/%s/index.htm', 'U+%s'),
 
     # These should be identical: one for links, one for full URL display
-    'unicode13':         ('https://www.unicode.org/versions/Unicode13.0.0%s', ''),
+    'unicode13':         ('https://www.unicode.org/versions/Unicode13.0.0%s', None),
     'unicode13_display': ('https://www.unicode.org/versions/Unicode13.0.0%s', None),
 
     # These should be identical: one for links, one for full URL display
-    'xlink':         ('https://www.w3.org/TR/xlink11%s', ''),
+    'xlink':         ('https://www.w3.org/TR/xlink11%s', None),
     'xlink_display': ('https://www.w3.org/TR/xlink11%s', None),
 
-    'xml_help': ('https://www.w3.org/XML/%s', ''),
+    'xml_help': ('https://www.w3.org/XML/%s', None),
 
     # These should be identical: one for links, one for full URL display
-    'xml_1_1':         ('https://www.w3.org/TR/xml11%s', ''),
+    'xml_1_1':         ('https://www.w3.org/TR/xml11%s', None),
     'xml_1_1_display': ('https://www.w3.org/TR/xml11%s', None),
 
     # These should be identical: one for links, one for full URL display
-    'xml_infoset':         ('https://www.w3.org/TR/2004/REC-xml-infoset-20040204/%s', ''),
+    'xml_infoset':         ('https://www.w3.org/TR/2004/REC-xml-infoset-20040204/%s', None),
     'xml_infoset_display': ('https://www.w3.org/TR/2004/REC-xml-infoset-20040204%s', None),
 
-    'xml_namespace_1_1':         ('https://www.w3.org/TR/xml-names11%s', ''),
+    'xml_namespace_1_1':         ('https://www.w3.org/TR/xml-names11%s', None),
     'xml_namespace_1_1_display': ('https://www.w3.org/TR/xml-names11%s', None),
 
 }
@@ -197,9 +197,9 @@ copyright = u'2019-{0}, CellML Editors and Contributors'.format(
 # built documents.
 #
 # The short X.Y version.
-version = '2.1'
+version = '2.0'
 # The full version, including alpha/beta/rc tags.
-release = '2.1'
+release = '2.0.1.rc1'
 if unofficial:
     version += '-unofficial'
     release += '-unofficial'
@@ -354,7 +354,7 @@ htmlhelp_basename = 'CellMLdoc'
 
 # -- Options for LaTeX output ---------------------------------------------
 
-latex_engine = 'xelatex'
+latex_engine = 'lualatex'
 
 latex_elements = {
     # The paper size ('letterpaper' or 'a4paper').

--- a/src/reference/formal_sectionA.rst
+++ b/src/reference/formal_sectionA.rst
@@ -1,8 +1,8 @@
 .. _sectionA_index_formal:
 
-=============
-1 Definitions 
-=============
+===========
+Definitions 
+===========
 
 .. toctree::
     :maxdepth: 2

--- a/src/reference/formal_sectionB.rst
+++ b/src/reference/formal_sectionB.rst
@@ -1,8 +1,8 @@
 .. _sectionB_index_formal:
 
-===========================
-2 Element information items
-===========================
+=========================
+Element information items
+=========================
 
 .. toctree::
     :maxdepth: 1

--- a/src/reference/formal_sectionC.rst
+++ b/src/reference/formal_sectionC.rst
@@ -1,8 +1,8 @@
 .. _sectionC_index_formal:
 
-================
-3 Interpretation
-================
+==============
+Interpretation
+==============
 
 .. toctree::
     :maxdepth: 1

--- a/src/reference/formal_sectionD.rst
+++ b/src/reference/formal_sectionD.rst
@@ -1,7 +1,7 @@
 .. _sectionD_index_formal:
 
-============
-4 References
-============
+==========
+References
+==========
 
 .. include:: sectionD_references.inc

--- a/src/reference/sectionA_definitions.inc
+++ b/src/reference/sectionA_definitions.inc
@@ -4,8 +4,8 @@
 
 .. _specA_terminology:
 
-1.1 Terminology
----------------
+Terminology
+-----------
 
 The keywords "MUST", "MUST NOT", "SHALL", "SHALL NOT", and "MAY" in this document are to be interpreted as described in :rfc2119:`RFC 2119 <>` [:ref:`1<ref_rfc2119>`].
 
@@ -92,18 +92,18 @@ Any one of the Unicode characters :unicode:`0009`, :unicode:`000A`, :unicode:`00
 
 .. _specA_cellml_information_sets:
 
-1.2 CellML information sets
----------------------------
+CellML information sets
+-----------------------
 
-1.2.1 CellML and XML
-~~~~~~~~~~~~~~~~~~~~
+CellML and XML
+~~~~~~~~~~~~~~
 
 1. Every :ref:`CellML infoset<specA_cellml_infoset>` SHALL be represented in an XML information set which conforms with the well-formedness requirements of :xml_1_1:`XML 1.1 <>` [:ref:`5<ref_xml_1_1>`].
 
 2. In this document, the remaining provisions relating to CellML infosets SHALL be interpreted as additional constraints on the XML information set represented by a CellML infoset.
 
-1.2.2 Specific information items
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Specific information items
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 1. For the purposes of this specification, a specific information item is one of the following (see :xml_infoset_display:`/` for definitions):
 
@@ -131,8 +131,8 @@ Any one of the Unicode characters :unicode:`0009`, :unicode:`000A`, :unicode:`00
 
 
 
-1.2.3 Non-specific information items
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Non-specific information items
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 1. For the purposes of this specification, a non-specific information item is one of the following (see :xml_infoset_display:`/` for definitions):
 
@@ -159,8 +159,8 @@ Any one of the Unicode characters :unicode:`0009`, :unicode:`000A`, :unicode:`00
 
 .. marker_cellml_information_sets_4
 
-1.2.4 Use of namespaces
-~~~~~~~~~~~~~~~~~~~~~~~
+Use of namespaces
+~~~~~~~~~~~~~~~~~
 
 1. Element information items in a :ref:`CellML infoset<specA_cellml_infoset>` MUST belong to one of the following namespaces, unless explicitly indicated otherwise:
 
@@ -170,8 +170,8 @@ Any one of the Unicode characters :unicode:`0009`, :unicode:`000A`, :unicode:`00
 
 2. Attribute information items in a CellML element MUST NOT be prefixed with a namespace, unless explicitly indicated otherwise.
 
-1.2.5 XML ID Attributes
-~~~~~~~~~~~~~~~~~~~~~~~
+XML ID Attributes
+~~~~~~~~~~~~~~~~~
 
 1. Any element information item in the :ref:`CellML namespace<specA_cellml_namespace>` MAY contain an attribute with local name :code:`id.`
 
@@ -182,8 +182,8 @@ Any one of the Unicode characters :unicode:`0009`, :unicode:`000A`, :unicode:`00
 
 .. _specA_data_representation_formats:
 
-1.3 Data representation formats in CellML
------------------------------------------
+Data representation formats in CellML
+-------------------------------------
 
 The following data representation formats are defined for use in this specification:
 

--- a/src/reference/sectionB_elements.inc
+++ b/src/reference/sectionB_elements.inc
@@ -524,8 +524,8 @@ A :code:`connection` element information item (referred to in this specification
 
 .. _map_variables:
 
-The ``map_variables`` element
------------------------------
+2.16 The ``map_variables`` element
+----------------------------------
 
 A :code:`map_variables` element information item (referred to in this specification as a :code:`map_variables` element) is an element in the :ref:`CellML namespace<specA_cellml_namespace>` with a local name equal to :code:`map_variables`, which appears as a child of a :code:`connection` element.
 

--- a/src/reference/sectionB_elements.inc
+++ b/src/reference/sectionB_elements.inc
@@ -4,8 +4,8 @@
 
 .. _model:
 
-2.1 The ``model`` element
--------------------------
+The ``model`` element
+---------------------
 
 The top-level element information item in a :ref:`CellML infoset<specA_cellml_infoset>` MUST be an element in the :ref:`CellML namespace<specA_cellml_namespace>` with a local name equal to :code:`model`.
 In this specification, the top-level element is referred to as the :code:`model` element.
@@ -45,8 +45,8 @@ In this specification, the top-level element is referred to as the :code:`model`
 
 .. _import:
 
-2.2 The ``import`` element
---------------------------
+The ``import`` element
+----------------------
 
 An :code:`import` element information item (referred to in this specification as an :code:`import` element) is an element in the :ref:`CellML namespace<specA_cellml_namespace>` with a local name equal to :code:`import`, which appears as a child of a :code:`model` element.
 
@@ -83,8 +83,8 @@ An :code:`import` element information item (referred to in this specification as
 
 .. _import_units:
 
-2.3 The ``import units`` element
---------------------------------
+The ``import units`` element
+----------------------------
 
 An :code:`import units` element information item (referred to in this specification as an :code:`import units` element) is an element in the :ref:`CellML namespace<specA_cellml_namespace>` with a local name equal to :code:`units`, which appears as a child of an :code:`import` element.
 
@@ -111,8 +111,8 @@ An :code:`import units` element information item (referred to in this specificat
 
 .. _import_component:
 
-2.4 The ``import component`` element
-------------------------------------
+The ``import component`` element
+--------------------------------
 
 An :code:`import component` element information item (referred to in this specification as an :code:`import component` element) is an element in the :ref:`CellML namespace<specA_cellml_namespace>` with a local name equal to :code:`component`, which appears as a child of an :code:`import` element.
 
@@ -137,8 +137,8 @@ An :code:`import component` element information item (referred to in this specif
 
 .. _units:
 
-2.5 The ``units`` element
--------------------------
+The ``units`` element
+---------------------
 
 A :code:`units` element information item (referred to in this specification as a :code:`units` element) is an element in the :ref:`CellML namespace<specA_cellml_namespace>` with a local name equal to :code:`units`, which appears as a child of a :code:`model` element.
 
@@ -164,8 +164,8 @@ A :code:`units` element information item (referred to in this specification as a
 
 .. _unit:
 
-2.6 The ``unit`` element
-------------------------
+The ``unit`` element
+--------------------
 
 A :code:`unit` element information item (referred to in this specification as a :code:`unit` element) is an element in the :ref:`CellML namespace<specA_cellml_namespace>` with a local name equal to :code:`unit`, which appears as a child of a :code:`units` element.
 
@@ -216,8 +216,8 @@ A :code:`unit` element information item (referred to in this specification as a 
 
 .. _component:
 
-2.7 The ``component`` element
------------------------------
+The ``component`` element
+-------------------------
 
 A :code:`component` element information item (referred to in this specification as a :code:`component` element) is an element in the :ref:`CellML namespace<specA_cellml_namespace>` with a local name equal to :code:`component`, which appears as a child of a :code:`model` element.
 
@@ -250,8 +250,8 @@ A :code:`component` element information item (referred to in this specification 
 
 .. _variable:
 
-2.8 The ``variable`` element
-----------------------------
+The ``variable`` element
+------------------------
 
 A :code:`variable` element information item (referred to in this specification as a :code:`variable` element) is an element in the :ref:`CellML namespace<specA_cellml_namespace>` with a local name equal to :code:`variable`, which appears as a child of a :code:`component` element.
 
@@ -290,8 +290,8 @@ A :code:`variable` element information item (referred to in this specification a
 
 .. _reset:
 
-2.9 The ``reset`` element
--------------------------
+The ``reset`` element
+---------------------
 
 A :code:`reset` element information item (referred to in this specification as a :code:`reset` element) is an element in the :ref:`CellML namespace<specA_cellml_namespace>` with a local name equal to :code:`reset`, which appears as a child of a :code:`component` element.
 
@@ -346,8 +346,8 @@ A :code:`reset` element information item (referred to in this specification as a
 
 .. _test_value:
 
-2.10 The ``test_value`` element
--------------------------------
+The ``test_value`` element
+--------------------------
 
 A :code:`test_value` element information item (referred to in this specification as a :code:`test_value` element) is an element in the :ref:`CellML namespace<specA_cellml_namespace>` with a local name equal to :code:`test_value`, which appears as a child of a :code:`reset` element.
 
@@ -360,8 +360,8 @@ A :code:`test_value` element information item (referred to in this specification
 
 .. _reset_value:
 
-2.11 The ``reset_value`` element
---------------------------------
+The ``reset_value`` element
+---------------------------
 
 A :code:`reset_value` element information item (referred to in this specification as a :code:`reset_value` element) is an element in the :ref:`CellML namespace<specA_cellml_namespace>` with a local name equal to :code:`reset_value`, which appears as a child of a :code:`reset` element.
 
@@ -374,8 +374,8 @@ A :code:`reset_value` element information item (referred to in this specificatio
 
 .. _math:
 
-2.12 The ``math`` element
--------------------------
+The ``math`` element
+--------------------
 
 A :code:`math` element information item (referred to in this specification as a :code:`math` element) is an element in the MathML namespace, which appears as a child of a :code:`component` element, a :code:`test_value` element, or a :code:`reset_value` element.
 
@@ -458,8 +458,8 @@ A :code:`math` element information item (referred to in this specification as a 
 
 .. _encapsulation:
 
-2.13 The ``encapsulation`` element
-----------------------------------
+The ``encapsulation`` element
+-----------------------------
 
 An :code:`encapsulation` element information item (referred to in this specification as an :code:`encapsulation` element) is an element in the :ref:`CellML namespace<specA_cellml_namespace>` with a local name equal to :code:`encapsulation`, which appears as a child of a :code:`model` element.
 
@@ -472,8 +472,8 @@ An :code:`encapsulation` element information item (referred to in this specifica
 
 .. _component_ref:
 
-2.14 The ``component_ref`` element
-----------------------------------
+The ``component_ref`` element
+-----------------------------
 
 A :code:`component_ref` element information item (referred to in this specification as a :code:`component_ref` element) is an element in the :ref:`CellML namespace<specA_cellml_namespace>` with a local name equal to :code:`component_ref`, which appears as a child of an :code:`encapsulation` element.
 
@@ -494,8 +494,8 @@ A :code:`component_ref` element information item (referred to in this specificat
 
 .. _connection:
 
-2.15 The ``connection`` element
--------------------------------
+The ``connection`` element
+--------------------------
 
 A :code:`connection` element information item (referred to in this specification as a :code:`connection` element) is an element in the :ref:`CellML namespace<specA_cellml_namespace>` with a local name equal to :code:`connection`, which appears as a child of a :code:`model` element.
 
@@ -536,8 +536,8 @@ A :code:`connection` element information item (referred to in this specification
 
 .. _map_variables:
 
-2.16 The ``map_variables`` element
-----------------------------------
+The ``map_variables`` element
+-----------------------------
 
 A :code:`map_variables` element information item (referred to in this specification as a :code:`map_variables` element) is an element in the :ref:`CellML namespace<specA_cellml_namespace>` with a local name equal to :code:`map_variables`, which appears as a child of a :code:`connection` element.
 

--- a/src/reference/sectionB_elements.inc
+++ b/src/reference/sectionB_elements.inc
@@ -311,6 +311,12 @@ A :code:`reset` element information item (referred to in this specification as a
          
          1. The value of the :code:`test_variable` attribute MUST be a valid variable reference, as defined in :numref:`{number} {name}<specC_variable_reference>`.
 
+      3. The :code:`order` attribute.
+
+         1. The value of the :code:`order` attribute MUST be an :ref:`integer string<specA_integer>`.
+
+         2. The value of the :code:`order` attribute MUST be unique for all :code:`reset` elements with :code:`variable` attributes that reference variables in the same equivalent variable set (see :numref:`{number} {name}<specC_interpretation_of_map_variables>`).
+
 .. marker_reset_2
 
    .. container:: issue-2-9-1-3

--- a/src/reference/sectionB_elements.inc
+++ b/src/reference/sectionB_elements.inc
@@ -191,15 +191,21 @@ A :code:`unit` element information item (referred to in this specification as a 
 
       .. container:: issue-2-6-2-1
 
-         1. The :code:`prefix` attribute. If present, the value of the attribute MUST meet the constraints specified in :numref:`{number} {name}<specC_interpretation_of_units>`.
+         1. The :code:`prefix` attribute.
+
+            1. If present, the value of the attribute MUST meet the constraints specified in :numref:`{number} {name}<specC_interpretation_of_units>`.
 
       .. container:: issue-2-6-2-2
 
-         2. The :code:`multiplier` attribute. If present, the value of the attribute MUST be a :ref:`real number string<specA_real_number>`.
+         2. The :code:`multiplier` attribute.
+
+            1. If present, the value of the attribute MUST be a :ref:`real number string<specA_real_number>`.
 
       .. container:: issue-2-6-2-3
 
-         3. The :code:`exponent` attribute. If present, the value of the attribute MUST be a :ref:`real number string<specA_real_number>`.
+         3. The :code:`exponent` attribute.
+
+            1. If present, the value of the attribute MUST be a :ref:`real number string<specA_real_number>`.
 
 .. note::
 

--- a/src/reference/sectionC_interpretation.inc
+++ b/src/reference/sectionC_interpretation.inc
@@ -4,8 +4,8 @@
 
 .. _specC_interpretation_of_imports:
 
-3.1 Interpretation of ``import`` elements
------------------------------------------
+Interpretation of ``import`` elements
+-------------------------------------
 
 1. Each :code:`import units` or :code:`import component` element present in a :ref:`CellML infoset<specA_cellml_infoset>` (the importing infoset) SHALL define a new and distinct instance of the CellML infoset (the imported infoset) that is specified by the parent :code:`import` element's :code:`href` attribute.
 
@@ -26,8 +26,8 @@
 
 .. _specC_units_reference:
 
-3.2 Units references
---------------------
+Units references
+----------------
 
 A "units reference" is an attribute value that specifies the physical units a variable or number is in.
 
@@ -138,8 +138,8 @@ A "units reference" is an attribute value that specifies the physical units a va
 
 .. _specC_interpretation_of_units:
 
-3.3 Interpretation of ``units`` elements
-----------------------------------------
+Interpretation of ``units`` elements
+------------------------------------
 
 1. The :code:`units` element SHALL be interpreted as the product of its
    :code:`unit` element children, according to the following rules:
@@ -180,7 +180,7 @@ A "units reference" is an attribute value that specifies the physical units a va
    2. The built-in irreducible units (those built-in units with "-" in the "Unit reduction tuple" column of :numref:`Table {number}: {name}<table_built_in_units>`) referenced by variables or other units in the model.
 
 .. marker_interpretation_of_units_2
-.. _specC_unit_reduction
+.. _specC_unit_reduction:
 
 3. The "unit reduction" is a conceptual property of :code:`units` elements.
    It consists of a set of tuples where each tuple is composed of a "unit name" and a real-valued "exponent".
@@ -254,8 +254,8 @@ A "units reference" is an attribute value that specifies the physical units a va
 
 .. _specC_component_reference:
 
-3.4 Component references
-------------------------
+Component references
+--------------------
 
 A "component reference" is an attribute value that specifies a CellML component.
 
@@ -278,8 +278,8 @@ A "component reference" is an attribute value that specifies a CellML component.
 
 .. _specC_variable_reference:
 
-3.5 Variable references
------------------------
+Variable references
+-------------------
 
 A "variable reference" is an attribute value that specifies a CellML variable.
 
@@ -301,8 +301,8 @@ A "variable reference" is an attribute value that specifies a CellML variable.
 .. _specC_interpretation_of_initial_values:
 
 
-3.6 Interpretation of ``initial_value`` attributes
---------------------------------------------------
+Interpretation of ``initial_value`` attributes
+----------------------------------------------
 
 1. The conditions under which initial values hold are (by design) not defined in a :ref:`CellML model<specA_cellml_model>`.
 
@@ -318,8 +318,8 @@ A "variable reference" is an attribute value that specifies a CellML variable.
 .. _specC_effect_of_units_on_variables:
 
 
-3.7 Effect of ``units`` on a ``variable``
------------------------------------------
+Effect of ``units`` on a ``variable``
+-------------------------------------
 
 1. The target of the :code:`units` attribute on a variable is referred to as the "variable units", and the corresponding unit reduction (see :numref:`{number} {name}<specC_interpretation_of_units>`) is referred to as the "variable unit reduction".
 
@@ -329,8 +329,8 @@ A "variable reference" is an attribute value that specifies a CellML variable.
 .. _specC_interpretation_of_mathematics:
 
 
-3.8 Interpretation of ``math`` elements
----------------------------------------
+Interpretation of ``math`` elements
+-----------------------------------
 
 1. The following :code:`component` elements SHALL, for the purposes of this specification, be "pertinent component elements":
 
@@ -355,8 +355,8 @@ A "variable reference" is an attribute value that specifies a CellML variable.
 .. _specC_interpretation_of_encapsulation:
 
 
-3.9 Interpretation of ``encapsulation`` elements
-------------------------------------------------
+Interpretation of ``encapsulation`` elements
+--------------------------------------------
 
 1. For the purposes of this specification, there SHALL be a conceptual "encapsulation digraph" in which there is exactly one node for every component in the :ref:`CellML model<specA_cellml_model>`.
 
@@ -387,8 +387,8 @@ A "variable reference" is an attribute value that specifies a CellML variable.
 
 .. _specC_interpretation_of_map_variables:
 
-3.10 Interpretation of ``map_variables`` elements
--------------------------------------------------
+Interpretation of ``map_variables`` elements
+--------------------------------------------
 
 1.  For the purposes of this specification, the conceptual "variable equivalence network" SHALL be an undirected graph with one node for every :code:`variable` element in the :ref:`CellML model<specA_cellml_model>`.
     
@@ -465,8 +465,8 @@ A "variable reference" is an attribute value that specifies a CellML variable.
 .. marker_interpretation_of_map_variables_end
 .. marker_interpretation_of_resets_start
 
-3.11 Interpretation of ``reset`` elements
------------------------------------------
+Interpretation of ``reset`` elements
+------------------------------------
 
 1. For the purposes of this section, we define the "reset variable" to be the variable referenced by a :code:`reset` element's :code:`variable` attribute, and the "test variable" to be the variable referenced by its :code:`test_variable` attribute.
 


### PR DESCRIPTION
The manual heading numbering didn't work for the LatexPDF build. At least I have not yet found a way to get around the issue of Latex adding heading numbers automatically and having a contents available in the generated document.  Reverting the manual heading numbering to release the next version of the spec.