### PR TITLE
Hard code name for table references

### DIFF
--- a/src/conf.py
+++ b/src/conf.py
@@ -24,7 +24,7 @@ target_cellml_org = True
 # The short X.Y version.
 version = '2.0'
 # The full version, including alpha/beta/rc tags.
-release = '2.0.1.rc1'
+release = '2.0.1.rc2'
 
 if unofficial:
   tags.add('unofficial')

--- a/src/reference/sectionB_elements.inc
+++ b/src/reference/sectionB_elements.inc
@@ -387,7 +387,7 @@ A :code:`math` element information item (referred to in this specification as a 
 
 .. container:: issue-2-12-2
 
-   2. Each element child of a :code:`math` element MUST have an element-type name that is listed in :numref:`Table {number}: {name}<table_supported_mathml_elements>`.
+   2. Each element child of a :code:`math` element MUST have an element-type name that is listed in :numref:`Table {number}: Supported MathML elements<table_supported_mathml_elements>`.
 
 .. marker_math_2
 
@@ -415,6 +415,7 @@ A :code:`math` element information item (referred to in this specification as a 
 .. marker_math_4
 
 .. _table_supported_mathml_elements:
+
 .. table:: Supported MathML elements
   :widths: auto
 
@@ -454,6 +455,7 @@ A :code:`math` element information item (referred to in this specification as a 
   +----------------------------------+------------------------------------------------------------------+
 
 .. marker_math_end
+
 .. marker_encapsulation_start
 
 .. _encapsulation:

--- a/src/reference/sectionC_interpretation.inc
+++ b/src/reference/sectionC_interpretation.inc
@@ -148,7 +148,7 @@ Interpretation of ``units`` elements
     
       1. If the :code:`unit` element does not have a :code:`prefix` attribute, then the prefix term SHALL have value 0.
       2. If the :code:`prefix` attribute has a value which is an :ref:`integer string<specA_integer>`, then the value of the prefix term SHALL be the numerical value of that string.
-      3. If the :code:`prefix` attribute has a value which is not an :ref:`integer string<specA_integer>`, then the attribute MUST have a value taken from the "Name" column of :numref:`Table {number}: {name}<table_prefix_values>`, and the prefix term SHALL have the value taken from the "Value" column of the same row.
+      3. If the :code:`prefix` attribute has a value which is not an :ref:`integer string<specA_integer>`, then the attribute MUST have a value taken from the "Name" column of :numref:`Table {number}: Prefix values<table_prefix_values>`, and the prefix term SHALL have the value taken from the "Value" column of the same row.
 
    2. The exponent term is a conceptual property of :code:`unit` elements.
       
@@ -248,6 +248,7 @@ Interpretation of ``units`` elements
   :code:`zepto`    −21
   :code:`yocto`    −24
   ============== ==========
+
 
 .. marker_interpretation_of_units_end
 .. marker_component_reference_start


### PR DESCRIPTION
Doing this probably because of a bug in sphinx.