### PR TITLE
Spec correction for `component_ref`

### DIFF
--- a/src/conf.py
+++ b/src/conf.py
@@ -69,6 +69,8 @@ def define_excluded_patterns():
     if build_type == 'Normative':
         exclude_patterns = ['master_index.rst',
                             'reference/index_section*',
+                            'reference/sectionB_elements.inc',
+                            'reference/sectionC_interpretation.inc',
                             'reference/examples/*/*.rst',
                             'reference/formal_and_informative/*.rst',
                             'reference/informative/*.rst',

--- a/src/master_index.rst
+++ b/src/master_index.rst
@@ -6,6 +6,7 @@ Informative CellML 2.0 Specification
 
 .. toctree::
     :maxdepth: 1
+    :numbered:
 
     reference/index_sectionA.rst
     reference/index_sectionB.rst

--- a/src/normative_only_index.rst
+++ b/src/normative_only_index.rst
@@ -20,6 +20,7 @@ The official version of the CellML Normative Specification is available at :cell
 
 .. toctree::
     :maxdepth: 2
+    :numbered:
 
     reference/formal_sectionA.rst
     reference/formal_sectionB.rst

--- a/src/reference/sectionB_elements.inc
+++ b/src/reference/sectionB_elements.inc
@@ -474,7 +474,7 @@ An :code:`encapsulation` element information item (referred to in this specifica
 The ``component_ref`` element
 -----------------------------
 
-A :code:`component_ref` element information item (referred to in this specification as a :code:`component_ref` element) is an element in the :ref:`CellML namespace<specA_cellml_namespace>` with a local name equal to :code:`component_ref`, which appears as a child of an :code:`encapsulation` element.
+A :code:`component_ref` element information item (referred to in this specification as a :code:`component_ref` element) is an element in the :ref:`CellML namespace<specA_cellml_namespace>` with a local name equal to :code:`component_ref`, which appears as a descendant of an :code:`encapsulation` element.
 
 .. container:: issue-2-14-1
 


### PR DESCRIPTION
Small fix to definition of `component_ref`.
Put heading numbers back in place for `html` build of documentation.
Fix cross referencing issue for `html` build.